### PR TITLE
Save report in a standard Junit4 format

### DIFF
--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1711,7 +1711,7 @@ def upload_json_report(Userid, temp_ini_file, run_id, all_run_id_info):
         json.dump(all_run_id_info, f, indent=2)
 
     # Create a standard report format to be consumed by other tools.
-    junit_report_path = zip_path / "report.xml"
+    junit_report_path = zip_path / "junitreport.xml"
     junit_report.process(all_run_id_info, str(junit_report_path))
 
 
@@ -1963,6 +1963,17 @@ def main(device_dict, user_info_object):
             CommonUtil.ExecLog(sModuleInfo, "Test Set Cancelled by the User", 1)  # add log
         elif not run_id.startswith("debug"):
             upload_json_report(Userid, temp_ini_file, run_id, all_run_id_info)
+            
+            # If node is running in device farm, copy the logs and reports to
+            # the expected directory.
+            if "DEVICEFARM_LOG_DIR" in os.environ:
+                log_dir = Path(os.environ["DEVICEFARM_LOG_DIR"])
+                zeuz_log_dir = Path(ConfigModule.get_config_value(
+                    "sectionOne", "test_case_folder", temp_ini_file
+                )).parent
+
+                shutil.copytree(str(zeuz_log_dir), str(log_dir))
+            
             # executor.submit(upload_json_report)
 
         # Close websocket connection.

--- a/reporting/junit_report.py
+++ b/reporting/junit_report.py
@@ -1,0 +1,65 @@
+import xml.etree.ElementTree as ET
+import json
+
+# Spec:
+# https://www.ibm.com/support/knowledgecenter/SSQ2R2_9.1.1/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html
+
+
+def process(data, save_path="report.xml"):
+    # For now we'll only deal with one run-id
+    data = data[0]
+
+    testsuite = ET.Element("testsuite")
+    testsuite.set("id", data["run_id"])
+    testsuite.set("name", data["TestObjective"])
+    testsuite.set("tests", str(len(data["test_cases"])))
+    testsuite.set("duration", data["execution_detail"]["duration"])
+    testsuite.set("timestamp", data["execution_detail"]["teststarttime"])
+
+    # Number of failed test cases.
+    failures = 0
+
+    for tc in data["test_cases"]:
+        testcase = ET.SubElement(testsuite, "testcase")
+        testcase.set("id", tc["testcase_no"])
+        testcase.set("name", tc["title"])
+        testcase.set("time", tc["execution_detail"]["duration"])
+
+        if tc["execution_detail"]["status"].lower() == "passed":
+            # Skip passed test cases.
+            continue
+
+        # Failure/error details related code.
+        failures += 1
+        try:
+            for step in tc["steps"]:
+                if step["execution_detail"]["status"].lower() == "passed":
+                    # Skip passed steps.
+                    continue
+                failure = ET.SubElement(testcase, "failure")
+                failure.set("type", step["step_name"])
+                failure.set("message", step["step_name"] + " failed")
+                failure.text = tc["execution_detail"]["failreason"]
+        except:
+            pass
+
+    testsuite.set("failures", str(failures))
+
+    ET.ElementTree(testsuite).write(
+        save_path,
+        encoding="UTF-8",
+        xml_declaration=True
+    )
+
+
+def main():
+    data = None
+    with open("reporting/sample.json", "r") as f:
+        data = json.loads(f.read())
+    
+    #print(data)
+    process(data, "reporting/report.xml")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This format is a standard across the industry and hence can be parsed by differnet reporting tools, including but not limited to AWS Device Farm and Jenkins.