### PR TITLE
Add partial range list access syntax

### DIFF
--- a/Framework/Built_In_Automation/Shared_Resources/BuiltInFunctionSharedResources.py
+++ b/Framework/Built_In_Automation/Shared_Resources/BuiltInFunctionSharedResources.py
@@ -431,16 +431,20 @@ class VariableParser:
                 try: right = int(right)
                 except: right = Get_Shared_Variables(right, log=False)
 
-                if "zeuz_failed" in (left, right):
-                    return None
+                if "zeuz_failed" == left:
+                    left = None
                 else:
                     left = int(left)
+
+                if "zeuz_failed" == right:
+                    right = None
+                else:
                     right = int(right)
 
-                return (left, right)
+                return left, right
 
         except: pass
-        return None
+        return None, None
 
 
     @staticmethod
@@ -584,13 +588,30 @@ def parse_variable(name):
                     val = val[_variable]
                 elif _slice is not None:
                     left, right = _slice
-                    val = val[left:right]
+                    if left is None and right:
+                        val = val[:right]
+                    elif right is None and left:
+                        val = val[left:]
+                    if left is None and right is None:
+                        CommonUtil.ExecLog(
+                            sModuleInfo,
+                            "Invalid left and right index for ranged variable access.",
+                            3,
+                        )
+                        return "zeuz_failed"
+                    else:
+                        val = val[left:right]
 
             # Print to console.
             CommonUtil.prettify(copy_of_name, val)
             return val
     except:
-        print("Failed to parse variable")
+        CommonUtil.ExecLog(
+            sModuleInfo,
+            "Failed to parse variable",
+            3,
+        )
+        print("")
         return "zeuz_failed"
 
 

--- a/Framework/Built_In_Automation/Web/REST/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/REST/BuiltInFunctions.py
@@ -1283,7 +1283,7 @@ def Validate_Step_Data(step_data):
 
         for each in step_data:
             if "graphql" in each[1]:
-                graphql_dict[each[0].strip()] = each[2]
+                graphql_dict[each[0].strip()] = CommonUtil.parse_value_into_object(each[2])
             elif each[1].lower().strip() == "element parameter":
                 element_parameter = each[0].lower().strip()
                 if element_parameter == "method":


### PR DESCRIPTION
Added new range syntax that allows list access with only one starting/ending index.

```python
my_list = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
my_list[0] = 0
my_list[-2] = 9
my_list[2:5] = [2, 3, 4]
my_list[:3] = [0, 1, 2]
my_list[:-1] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
my_list[3:] = [3, 4, 5, 6, 7, 8, 9, 10]
my_list[1:] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
```