### PR TITLE
Fix clear text mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Version 13.6.x
 
-### [13.6.3] [May 12, 2021] 
-- **[Fix]** Selenium "Enter text" action: on mac, `Command + a` must be used to select all text in a text field.
 ### [13.6.0] [May 12, 2021] 
 - **[Add]** For Loop and While Loop can now fail the step when exit condition is met. Also introduced "any" parameter
 ### [13.6.1] [May 13, 2021]
@@ -11,6 +9,8 @@
 - **[Add]** New Replace string action added
 ### [13.6.2] [May 18, 2021]
 - **[Add]** "String" append to [List] is handled in "Save variable - number string list dictionary" action
+### [13.6.3] [May 12, 2021] 
+- **[Fix]** Selenium "Enter text" action: on mac, `Command + a` must be used to select all text in a text field.
 
 ## Version 13.5.x
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Version 13.6.x
 
+### [13.6.3] [May 12, 2021] 
+- **[Fix]** Selenium "Enter text" action: on mac, `Command + a` must be used to select all text in a text field.
 ### [13.6.0] [May 12, 2021] 
 - **[Add]** For Loop and While Loop can now fail the step when exit condition is met. Also introduced "any" parameter
 ### [13.6.1] [May 13, 2021]
@@ -28,7 +30,7 @@
 
 ### [13.3.0] [Apr 07, 2021]
 - **[Add]** Added support for automating desktop web browser test cases on
-  mobile browsers.
+mobile browsers.
 - **[Fix]** Fixed a bug where node was checking if appium started up for 10
   seconds without any delay in between. This is unreliable and increases CPU
   load unnecessarily.

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -893,7 +893,10 @@ def Enter_Text_In_Text_Box(step_data):
                 if selenium_driver.desired_capabilities['browserName'] == "Safari":
                     Element.clear()
                 else:
-                    Element.send_keys(Keys.CONTROL, "a")
+                    if sys.platform == "darwin":
+                        Element.send_keys(Keys.COMMAND, "a")
+                    else:
+                        Element.send_keys(Keys.CONTROL, "a")
                     Element.send_keys(Keys.DELETE)
                     try:
                         Element.clear() #some cases it works .. so adding it here just incase

--- a/Framework/Version.txt
+++ b/Framework/Version.txt
@@ -1,4 +1,4 @@
 [ZeuZ Python Version]
-version = 13.6.2
+version = 13.6.3
 [Release Date]
-date = May 18, 2021
+date = May 27, 2021


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made.
- [x] Version number has been updated.
- [x] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Selenium "Enter text" action: on mac, `Command + a` must be used to select all text in a text field.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
