### PR TITLE
Run once with `-o` or `--once` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Version 14.0.x
-
+### [14.0.4] [June 20, 2021]
+- **[Add]** [internal] Node_state.json is generated to communicate between nodes and node_manager
 ### [14.0.3] [June 20, 2021]
 - **[Fix]** [internal] Node's main driver crashes/exceptions should not bubble
   up to top level.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Version 14.0.x
 
+### [14.0.3] [June 20, 2021]
+- **[Fix]** [internal] Node's main driver crashes/exceptions should not bubble
+  up to top level.
+- **[Fix]** jUnit report generation error.
+- **[Add]** Add `-o`, `--once` flag for running only a single session and then
+  quit node automatically. Useful for daemons, cron jobs & CI/CD.
+
 ### [14.0.0] [June 04, 2021]
 - **[Change]** Changed attachment variable parsing
 - **[Add]** Added file path option in execute python code action

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -6,7 +6,7 @@ import sys
 import inspect
 import os, os.path, threading
 import ast
-import json
+import json, time
 import logging
 from Framework.Utilities import ConfigModule
 import datetime
@@ -338,8 +338,23 @@ def Result_Analyzer(sTestStepReturnStatus, temp_q):
     except Exception as e:
         return Exception_Handler(sys.exc_info())
 
+
+def node_manager_json(data):
+    """ Generates a json file to communicate with node_manager"""
+    json_path = Path(os.path.abspath(__file__)).parent.parent.parent / "node_state.json"
+    with open(json_path, "w") as f:
+        json.dump(data, f)
+
+node_manager_json(
+    {
+        "state": "starting",
+        "report": {
+            "zip": None,
+            "directory": None,
+        }
+    }
+)
 report_json_time = 0.0
-import time
 
 
 def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):

--- a/Framework/Version.txt
+++ b/Framework/Version.txt
@@ -1,4 +1,4 @@
 [ZeuZ Python Version]
-version = 14.0.0
+version = 14.0.3
 [Release Date]
-date = June 04, 2021
+date = June 20, 2021

--- a/Framework/Version.txt
+++ b/Framework/Version.txt
@@ -1,4 +1,4 @@
 [ZeuZ Python Version]
-version = 14.0.3
+version = 14.0.4
 [Release Date]
 date = June 20, 2021

--- a/node_cli.py
+++ b/node_cli.py
@@ -331,7 +331,16 @@ def Login(cli=False, run_once=False):
                             CommonUtil.ExecLog(
                                 "", "Time zone settings failed {}".format(e), 4, False
                             )
-
+                        # Telling the node_manager that the node is ready to deploy
+                        CommonUtil.node_manager_json(
+                            {
+                                "state": "idle",
+                                "report": {
+                                    "zip": None,
+                                    "directory": None,
+                                }
+                            }
+                        )
                         run_again = RunProcess(tester_id, user_info_object, run_once=run_once)
 
                         if not run_again:
@@ -398,7 +407,7 @@ def Login(cli=False, run_once=False):
             time.sleep(60)
 
     if run_once:
-        CommonUtil.ExecLog(
+        print(
             "[OFFLINE]", "Zeuz Node is going offline after running one session, since `--once` or `-o` flag is specified.", 4
         )
     else:
@@ -453,7 +462,16 @@ def RunProcess(sTesterid, user_info_object, run_once=False):
                 z.close()
                 os.unlink(save_path/"input.zip")
                 PreProcess()
-
+                # Telling the node_manager that a run_id is deployed
+                CommonUtil.node_manager_json(
+                    {
+                        "state": "in_progress",
+                        "report": {
+                            "zip": None,
+                            "directory": None,
+                        }
+                    }
+                )
                 try:
                     value = MainDriverApi.main(device_dict, user_info_object)
                 except:

--- a/node_cli.py
+++ b/node_cli.py
@@ -453,7 +453,11 @@ def RunProcess(sTesterid, user_info_object, run_once=False):
                 z.close()
                 os.unlink(save_path/"input.zip")
                 PreProcess()
-                value = MainDriverApi.main(device_dict, user_info_object)
+
+                try:
+                    value = MainDriverApi.main(device_dict, user_info_object)
+                except:
+                    value = None
 
                 if run_once:
                     return False

--- a/reporting/junit_report.py
+++ b/reporting/junit_report.py
@@ -11,7 +11,12 @@ def process(data, save_path="report.xml"):
 
     testsuite = ET.Element("testsuite")
     testsuite.set("id", data["run_id"])
-    testsuite.set("name", data["objective"])
+
+    if "objective" in data:
+        testsuite.set("name", data["objective"])
+    else:
+        testsuite.set("name", data["TestObjective"])
+
     testsuite.set("tests", str(len(data["test_cases"])))
     testsuite.set("duration", data["execution_detail"]["duration"])
     testsuite.set("timestamp", data["execution_detail"]["teststarttime"])


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature + Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made.
- [x] Version number has been updated.
- [x] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
- `node_cli.py` now accepts a new flag: `-o` or `--once` which will execute only a single session and then quit automatically.
- Node's main driver crashes/exceptions should not bubble up to top level.
- jUnit report generation error.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
