### PR TITLE
Zeuz internal api auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 # Version 14.x.x
 ## Version 14.4.x
 
+### [14.4.1] [September 27, 2021]
+
+- **[Change]** All internal APIs that communicate with Zeuz Server are now
+  authenticated by API key. Only API key based login is going to work now.
+
 ### [14.4.0] [September 6, 2021]
 
 - **[Add]** Desktop record and replay action! Record your mouse interactions

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1264,19 +1264,23 @@ def upload_json_report(Userid, temp_ini_file, run_id):
                 size = str(size) + " KB"
             print("Uploading %s report of %s testcases of %s from:\n%s"
                   % (CommonUtil.current_session_name, len(json_report[0]["test_cases"]), size, str(zip_path) + ".zip"))
-            for i in range(5):
+
+            headers = RequestFormatter.add_api_key_to_headers({})
+            for _ in range(5):
                 try:
                     res = requests.post(
                         RequestFormatter.form_uri("create_report_log_api/"),
                         files={"file": fzip},
                         data={"machine_name": Userid, "file_name": json_report[CommonUtil.runid_index]["file_name"]},
-                        verify=False)
+                        verify=False,
+                        **headers)
                 except KeyError:
                     res = requests.post(
                         RequestFormatter.form_uri("create_report_log_api/"),
                         files={"file": fzip},
                         data={"machine_name": Userid},
-                        verify=False)
+                        verify=False,
+                        **headers)
                 if res.status_code == 200:
                     try:
                         res_json = res.json()

--- a/Framework/Utilities/RequestFormatter.py
+++ b/Framework/Utilities/RequestFormatter.py
@@ -6,47 +6,72 @@ import requests
 import json
 from urllib3.exceptions import InsecureRequestWarning
 
-SERVER_TAG = "Authentication"
+# Tags for reading data from settings.conf file.
+AUTHENTICATION_CATEGORY = "Authentication"
 SERVER_ADDRESS_TAG = "server_address"
-SERVER_PORT = "server_port"
+SERVER_PORT_TAG = "server_port"
+API_KEY_TAG = "api-key"
+
 REQUEST_TIMEOUT = 2 * 60
+
+API_KEY_HEADER_NAME = "X-API-KEY"
 
 # Suppress the InsecureRequestWarning since we use verify=False parameter.
 requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 
 
 def form_uri(resource_path):
-    web_server_address = ConfigModule.get_config_value(SERVER_TAG, SERVER_ADDRESS_TAG)
+    web_server_address = ConfigModule.get_config_value(AUTHENTICATION_CATEGORY, SERVER_ADDRESS_TAG)
     base_server_address = web_server_address
     if len(resource_path) > 0:
         if resource_path[0] == "/":
             resource_path = resource_path[1:]
-        base_server_address += "/" + resource_path 
+        base_server_address += "/" + resource_path
 
     return base_server_address
 
 
-def Post(resource_path, payload=None):
+def add_api_key_to_headers(kwargs):
+    """
+    Adds the 'X-API-KEY' header to the passed dictionary's 'headers' key, which
+    is used for every request. This makes it easy to authenticate all zeuz
+    server requests without having to manually specifying the API key
+    everywhere.
+    """
+
+    api_key = ConfigModule.get_config_value(AUTHENTICATION_CATEGORY, API_KEY_TAG)
+    if api_key:
+        if "headers" in kwargs:
+            kwargs["headers"][API_KEY_HEADER_NAME] = api_key
+        else:
+            kwargs["headers"] = { API_KEY_HEADER_NAME: api_key }
+    return kwargs
+
+
+def Post(resource_path, payload=None, **kwargs):
     if payload is None:  # Removing default mutable argument
         payload = {}
     try:
+        kwargs = add_api_key_to_headers(kwargs)
         return requests.post(
             form_uri(resource_path + "/"),
             data=json.dumps(payload),
             verify=False,
             timeout=REQUEST_TIMEOUT,
+            **kwargs
         ).json()
     except Exception as e:
         print("Post Exception: {}".format(e))
         return {}
 
 
-def Get(resource_path, payload=None,**kwargs):
+def Get(resource_path, payload=None, **kwargs):
     if payload is None:  # Removing default mutable argument
         payload = {}
     try:
+        kwargs = add_api_key_to_headers(kwargs)
         return requests.get(
-            form_uri(resource_path ),
+            form_uri(resource_path),
             params=json.dumps(payload),
             timeout=REQUEST_TIMEOUT,
             verify=False,
@@ -67,15 +92,17 @@ def Get(resource_path, payload=None,**kwargs):
 
 
 # here params are passed as a plain dictionary for better catching get parameter values
-def UpdatedGet(resource_path, payload=None):
+def UpdatedGet(resource_path, payload=None, **kwargs):
     if payload is None:  # Removing default mutable argument
         payload = {}
     try:
+        kwargs = add_api_key_to_headers(kwargs)
         return requests.get(
             form_uri(resource_path + "/"),
             params=payload,
             timeout=REQUEST_TIMEOUT,
             verify=False,
+            **kwargs
         ).json()
 
     except requests.exceptions.RequestException as e:
@@ -91,10 +118,16 @@ def UpdatedGet(resource_path, payload=None):
         return {}
 
 
-def Head(resource_path):
+def Head(resource_path, **kwargs):
     try:
+        kwargs = add_api_key_to_headers(kwargs)
         uri = form_uri(resource_path)
-        return requests.head(uri, timeout=REQUEST_TIMEOUT, verify=False)
+        return requests.head(
+            uri,
+            timeout=REQUEST_TIMEOUT,
+            verify=False,
+            **kwargs
+        )
 
     except requests.exceptions.RequestException:
         print(

--- a/Framework/Version.txt
+++ b/Framework/Version.txt
@@ -1,4 +1,4 @@
 [ZeuZ Python Version]
-version = 14.4.0
+version = 14.4.1
 [Release Date]
-date = September 6, 2021
+date = September 27, 2021

--- a/node_cli.py
+++ b/node_cli.py
@@ -427,7 +427,8 @@ def RunProcess(sTesterid, user_info_object, run_once=False):
                 return True  # Timeout reached, re-login. We do this because after about 3-4 hours this function will hang, and thus not be available for deployment
             executor.submit(RequestFormatter.Get, "update_machine_with_time_api", {"machine_name": sTesterid})
             # r = RequestFormatter.Get("is_run_submitted_api", {"machine_name": sTesterid})
-            r = requests.get(RequestFormatter.form_uri("is_submitted_api"), {"machine_name": sTesterid}, verify=False).json()
+            r = RequestFormatter.Get(f"is_submitted_api?machine_name={sTesterid}")
+            # r = requests.get(RequestFormatter.form_uri("is_submitted_api"), {"machine_name": sTesterid}, verify=False).json()
             Userid = (CommonUtil.MachineInfo().getLocalUser()).lower()
             if r and "found" in r and r["found"]:
                 size = round(int(r["file_size"]) / 1024, 2)
@@ -438,7 +439,8 @@ def RunProcess(sTesterid, user_info_object, run_once=False):
                 save_path = temp_ini_file.parent / "attachments"
                 CommonUtil.ExecLog("", "Downloading dataset and attachments of %s into:\n%s" % (size, str(save_path/"input.zip")), 4)
                 FL.CreateFolder(save_path)
-                response = requests.get(RequestFormatter.form_uri("getting_json_data_api"), {"machine_name": Userid}, stream=True, verify=False)
+                headers = RequestFormatter.add_api_key_to_headers({})
+                response = requests.get(RequestFormatter.form_uri("getting_json_data_api"), {"machine_name": Userid}, stream=True, verify=False, **headers)
                 chunk_size = 4096
                 progress_bar = tqdm(total=r["file_size"], unit='B', mininterval=0, unit_scale=True, unit_divisor=1024, leave=False)
                 with open(save_path/"input.zip", 'wb') as file:


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Internal feature set


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made.
- [x] Version number has been updated.
- [x] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
All APIs that communicate with Zeuz Server are now required to be authenticated. This PR makes sure all internal API calls provide the necessary api information to the different endpoints. However, this also means, when the Zeuz server is upgraded to the latest release - only API based login will work and previous node versions will stop working.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
