### PR TITLE
feat: Add `-d`, `--log_dir` for custom logging directory

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,14 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "Python: node_cli custom log dir",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/node_cli.py",
+            "args": ["-d /home/szxo3/Desktop/test_node_dir"],
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Python: node_gui",
             "type": "python",
             "request": "launch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
-# Version 14.x.x
-## Version 14.5.x
+# Version 14
+
+### [14.6.0] [October 31, 2021]
+- **[Add]** Add support for specifying custom log directory. Usage:
+
+  ```shell
+  python node_cli.py -d /path/to/custom/dir
+  python node_cli.py --log_dir /path/to/custom/dir
+  ```
 
 ### [14.5.2] [October 19, 2021]
 - **[Add]** Dictionary support is added in compare variable action
@@ -22,7 +29,7 @@
 - **[Add]** Read and save mail action is added
 - **[Add]** Delete mail action is added
 - **[Add]** Search and save text using regex action is added
-## Version 14.4.x
+
 ### [14.4.0] [August 24, 2021]
 - **[Fix]** Fixed variable parsing limitations
 - **[Fix]** Fixed exact match bug and improved subset in compare_data action
@@ -32,10 +39,7 @@
 `%|list_name.sort()|%`
 `%|var_name.upper().strip().split(" ")|%`
 
-## Version 14.3.x
-
 ### [14.3.1] [August 28, 2021]
-
 - **[Add]** Parse port from database host url if specified in the form
   `127.0.0.1:8080` where the port is separated by a `:` symbol.
 
@@ -50,15 +54,16 @@
 - **[Fix]** All other desktop actions are fixed and improved
 - **[Change]** If all actions are disabled pass the step anyway
 - **[Change]** If internet goes down ZeuZ Node will now automatically handle the login when internet is up again
-## Version 14.2.x
+
 ### [14.2.0] [July 10, 2021]
 - **[Change]** Changed Report API to handle both server version
-## Version 14.1.x
+
 ### [14.1.0] [June 29, 2021]
 - **[Add]** [internal] Large sets will be uploaded in several sessions with maximum 25 testcases each
-## Version 14.0.x
+
 ### [14.0.4] [June 20, 2021]
 - **[Add]** [internal] Node_state.json is generated to communicate between nodes and node_manager
+
 ### [14.0.3] [June 20, 2021]
 - **[Fix]** [internal] Node's main driver crashes/exceptions should not bubble
   up to top level.
@@ -70,14 +75,10 @@
 - **[Change]** Changed attachment variable parsing
 - **[Add]** Added file path option in execute python code action
 
-# Version 13.x.x
-
-## Version 13.7.x
+# Version 13
 
 ### [13.7.0] [June 02, 2021] 
 - **[Add]** Partial case-insensitive search for web and mobile is added as **attribute = attribute_value
-
-## Version 13.6.x
 
 ### [13.6.4] [May 30, 2021] 
 - **[Add]** Added new action for iframe switching in web
@@ -91,21 +92,15 @@
 ### [13.6.0] [May 12, 2021] 
 - **[Add]** For Loop and While Loop can now fail the step when exit condition is met. Also introduced "any" parameter
 
-## Version 13.5.x
-
 ### [13.5.1] [May 12, 2021] 
 - **[Improve]** Split action improved to convert json and non json objects to string then split
 ### [13.5.0] [Apr 27, 2021] 
 - **[Improve]** Variable parsing improved for non json type objects
 
-## Version 13.4.x
-
 ### [13.4.0] [Apr 21, 2021] 
 - **[Add]** Appium new powerful "Scroll to an element" action is added
 - **[Fix]** Appium device, teardown and Windows terminal closing issue fixed
 - **[Add]** Appium seek progress bar action added
-
-## Version 13.3.x
 
 ### [13.3.2] [Apr 15, 2021] 
 - **[Remove]** Disabled `Rerun on fail` for now
@@ -120,8 +115,6 @@ mobile browsers.
   load unnecessarily.
 - **[Improve]** Improved 'For loop' to loop though selenium objects and perform 
   web actions on them
-
-## Version 13.2.x
 
 ### [13.2.7] [Apr 07, 2021]
 - **[Fix]** Bug fix of "Command separator" in run_command action
@@ -141,18 +134,15 @@ mobile browsers.
 ### [13.2.0] [Mar 27, 2021]
 - **[Add]** json report is added to zip file of report page for Performance action
 
-## Version 13.1.x
-
 ### [13.1.0] [Mar 23, 2021]
 - **[Add]** New improved for loop action is added with complex nested logics handling capabilities
-
-## Version 13.0.x
 
 ### [13.0.0] [Jan 01, 2021]
 - Implemented new well optimized ZeuZ Architecture which downloads all testcases at once before starting and upload
   report after all test cases are executed
 
-<br><br><br><br><br>
+---
+
 ## Version: 12.0.0
 
 > NOTE: This is the old changelog format.

--- a/Framework/Built_In_Automation/Built_In_Utility/CrossPlatform/BuiltInUtilityFunction.py
+++ b/Framework/Built_In_Automation/Built_In_Utility/CrossPlatform/BuiltInUtilityFunction.py
@@ -2205,8 +2205,6 @@ def Upload(step_data):
                 get_home_folder() + str(step_data[0][2]).strip()
             )  # location of the file/folder to be copied\
 
-            # temp_ini_file = get_home_folder() + "/Desktop/AutomationLog/temp_config.ini"
-
             temp_ini_file = os.path.join(
                 os.path.join(
                     os.path.abspath(__file__).split("Framework")[0],
@@ -2233,7 +2231,6 @@ def Upload(step_data):
                 str(step_data[0][0]).strip()
             )  # location of the file/folder to be copied
 
-            # temp_ini_file = get_home_folder() + raw("\Desktop\AutomationLog\temp_config.ini")
             temp_ini_file = os.path.join(
                 os.path.join(
                     os.path.abspath(__file__).split("Framework")[0],
@@ -2273,9 +2270,6 @@ def Upload(step_data):
 
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())
-
-
-# temp_config = os.path.join(os.path.join(get_home_folder(), os.path.join('Desktop', os.path.join('AutomationLog',ConfigModule.get_config_value('Temp', '_file')))))
 
 
 temp_config = os.path.join(

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1343,7 +1343,7 @@ def main(device_dict, user_info_object):
         Userid = (CommonUtil.MachineInfo().getLocalUser()).lower()
 
         get_json, all_file_specific_steps = True, {}
-        save_path = Path(ConfigModule.get_config_value("sectionOne", "temp_run_file_path", temp_ini_file)) / "attachments"
+        save_path = Path(temp_ini_file).parent / "attachments"
         cnt = 0
         for i in os.walk(save_path):
             if get_json:

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -43,10 +43,6 @@ colorama_init(autoreset=True)
 MODULE_NAME = inspect.getmodulename(__file__)
 
 # Get file path for temporary config file
-# temp_config = os.path.join(os.path.join(FL.get_home_folder(), os.path.join('Desktop', os.path.join('AutomationLog',ConfigModule.get_config_value('Advanced Options','_file')))))
-
-
-# temp_config = os.path.join(os.path.join (os.path.realpath(__file__).split("Framework")[0] , os.path.join ('AutomationLog',ConfigModule.get_config_value('Advanced Options', '_file'))))
 temp_config = Path(
     os.path.join(os.path.abspath(__file__).split("Framework")[0])
     / Path("AutomationLog")
@@ -54,7 +50,6 @@ temp_config = Path(
         ConfigModule.get_config_value(
             "Advanced Options",
             "_file",
-            Path(os.path.abspath(__file__)).parent.parent / Path("settings.conf"),
         )
     )
 )
@@ -994,8 +989,6 @@ class MachineInfo:
         :return: returns the local pc unique ID
         """
         try:
-            # node_id_file_path = os.path.join(FL.get_home_folder(), os.path.join('Desktop', 'node_id.conf'))
-            # node_id_file_path = os.path.join (os.path.realpath(__file__).split("Framework")[0] , os.path.join ('node_id.conf'))
             node_id_file_path = Path(
                 os.path.abspath(__file__).split("Framework")[0]
             ) / Path("node_id.conf")

--- a/Framework/Version.txt
+++ b/Framework/Version.txt
@@ -1,4 +1,4 @@
 [ZeuZ Python Version]
-version = 14.5.2
+version = 14.6.0
 [Release Date]
-date = October 19, 2021
+date = October 31, 2021


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated. *Manually tested*.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made.
- [x] Version number has been updated.
- [x] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Users can now specify a custom log directory for storing all node execution logs and reports. By default, it'll be stored inside node's "AutomationLog" folder.

### Usage
```shell
python node_cli.py -d /path/to/custom/dir
python node_cli.py --log_dir /path/to/custom/dir
```
<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
