### PR TITLE
API session and client cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 # Version 15
+
+### [15.1.0] [January 21, 2022]
+- **[Add]** Session based requests (same session requests will utilize
+  connection pooling, cookie sharing, etc.)
+- **[Add]** Ability to specify a an environment variable `ZEUZ_NODE_CLIENT_CERT`
+  which contains the location to the certificates directory or a default
+  certificate directory in `ZeuZ Node > Framework > certificates` so that every
+  API action will use these certificates to issue any kind of requests.
+
 ### [15.0.0] [January 21, 2022]
 - **[Change]** action_disable is flipped
 

--- a/Framework/Version.txt
+++ b/Framework/Version.txt
@@ -1,4 +1,4 @@
 [ZeuZ Python Version]
-version = 15.0.0
+version = 15.1.0
 [Release Date]
 date = January 21, 2022


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made.
- [x] Version number has been updated.
- [x] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This pull request adds the following two major features and one minor improvement:
1. Session based requests (same session requests will utilize connection pooling, cookie sharing, etc.)
2. Ability to specify a an environment variable `ZEUZ_NODE_CLIENT_CERT` which contains the location to the certificates directory or a default certificate directory in `ZeuZ Node > Framework > certificates` so that every API action will use these certificates to issue any kind of requests.
3. Add "pause for live log service connection" which will delay upto 6 secs if it can't connect.

Location to the certificate(s) file(s) is resolved in the following way:

1. Checks for `ZEUZ_NODE_CLIENT_CERT` environment variable which should
   point to the directory containing the certificate(s).
2. Tries to search for a `certificates` folder in the current `PYTHON PATH`.

If there are multiple type of certificates, they're resolved according to
the following priorities - 1 being the highest (pick first):

1. If there's a ".pem" file, it'll take the highest priority as the only
   certificate file.
2. If there's a pair of ".cert" and ".key" files, pick them.
3. If there's a pair of ".crt" and ".key" files, pick them.
4. If there's a pair of ".cer" and ".key" files, pick them.
5. Otherwise we pick nothing and return `None`.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
