### PR TITLE
[Add] os.environ['WDM_SSL_VERIFY'] = '0' is added for skipping ssl wh…

### DIFF
--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -69,6 +69,9 @@ temp_config = os.path.join(
     )
 )
 
+# Disable WebdriverManager SSL verification.
+os.environ['WDM_SSL_VERIFY'] = '0'
+
 global WebDriver_Wait
 WebDriver_Wait = 1
 global WebDriver_Wait_Short


### PR DESCRIPTION
## Overview
os.environ['WDM_SSL_VERIFY'] = '0' is added for skipping ssl while downloading webdrivers