### PR TITLE
Attachment hash same content fix

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,14 +15,16 @@
             "type": "python",
             "request": "launch",
             "program": "${file}",
-            "console": "integratedTerminal"
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
         },
         {
             "name": "Python: node_cli",
             "type": "python",
             "request": "launch",
             "program": "${workspaceFolder}/node_cli.py",
-            "console": "integratedTerminal"
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
         },
         {
             "name": "Python: node_cli custom log dir",
@@ -30,7 +32,8 @@
             "request": "launch",
             "program": "${workspaceFolder}/node_cli.py",
             "args": ["-d /home/szxo3/Desktop/test_node_dir"],
-            "console": "integratedTerminal"
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
         },
         {
             "name": "Python: local_run",
@@ -38,7 +41,8 @@
             "request": "launch",
             "program": "${workspaceFolder}/node_cli.py",
             "args": ["--local_run"],
-            "console": "integratedTerminal"
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
         },
         {
             "name": "Python: node_cli with GH_TOKEN",
@@ -46,7 +50,8 @@
             "request": "launch",
             "program": "${workspaceFolder}/node_cli.py",
             "args": ["--gh", "TOKEN_HERE"],
-            "console": "integratedTerminal"
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
         },
     ]
 }

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1396,46 +1396,42 @@ def download_attachments(testcase_info):
 
     # Test case attachments
     for attachment in testcase_info["attachments"]:
-        # entry = db.exists(attachment["hash"])
+        entry = db.exists(attachment["hash"])
         to_append = {
             "url": url_prefix + attachment["path"],
             "download_dir": attachment_path,
             "attachment": attachment,
         }
-        urls.append(to_append)
-
-        # if entry is None:
-        #     urls.append(to_append)
-        # else:
-        #     try:
-        #         shutil.copyfile(str(entry["path"]), attachment_path / entry["name"])
-        #     except:
-        #         # If copy fails, the file either does not exist or we don't have
-        #         # permission. Download the file again and remove from db.
-        #         urls.append(to_append)
-        #         db.remove(entry["hash"])
+        if entry is None:
+            urls.append(to_append)
+        else:
+            try:
+                shutil.copyfile(str(entry["path"]), attachment_path / Path(attachment["path"].name))
+            except:
+                # If copy fails, the file either does not exist or we don't have
+                # permission. Download the file again and remove from db.
+                urls.append(to_append)
+                db.remove(entry["hash"])
 
     # Step attachments
     for step in testcase_info["steps"]:
         for attachment in step["attachments"]:
-            # entry = db.exists(attachment["hash"])
+            entry = db.exists(attachment["hash"])
             to_append = {
                 "url": url_prefix + attachment["path"],
                 "download_dir": attachment_path,
                 "attachment": attachment,
             }
-            urls.append(to_append)
-
-            # if entry is None:
-            #     urls.append(to_append)
-            # else:
-            #     try:
-            #         shutil.copyfile(str(entry["path"]), attachment_path / entry["name"])
-            #     except:
-            #         # If copy fails, the file either does not exist or we don't have
-            #         # permission. Download the file again and remove from db.
-            #         urls.append(to_append)
-            #         db.remove(entry["hash"])
+            if entry is None:
+                urls.append(to_append)
+            else:
+                try:
+                    shutil.copyfile(str(entry["path"]), attachment_path / Path(attachment["path"].name))
+                except:
+                    # If copy fails, the file either does not exist or we don't have
+                    # permission. Download the file again and remove from db.
+                    urls.append(to_append)
+                    db.remove(entry["hash"])
 
     results = ThreadPool(4).imap_unordered(download_attachment, urls)
     for r in results:

--- a/Framework/attachment_db.py
+++ b/Framework/attachment_db.py
@@ -4,12 +4,6 @@ import json
 from pathlib import Path
 import time
 from typing import Any, Dict, Union
-import random
-import string
-
-
-def random_string(n: int) -> str:
-    return ''.join(random.choice(string.ascii_lowercase) for _ in range(n))
 
 
 class AttachmentDB:
@@ -17,8 +11,6 @@ class AttachmentDB:
         self.db_directory = db_directory
         self.db_file = db_directory / "db.json"
         self.init_db()
-        self.path_suffix = ".zeuz."
-        self.suffix_length = 8
 
 
     def exists(self, hash: str) -> Union[Dict[str, str], None]:
@@ -62,26 +54,24 @@ class AttachmentDB:
         if len(hash) == 0 or hash == "0":
             return None
 
+        db = self.get_db()
+
+        if hash in db:
+            return None
+
         modified_at = time.time()
 
         # We add a random suffix to the filepath to make sure files with same
         # names but different hashes do not overwrite each other. Specially
         # important if there are multiple attachments across multiple test
         # cases/steps with the same file name.
-        path = filepath.with_suffix(
-            filepath.suffix +
-            self.path_suffix +
-            random_string(self.suffix_length)
-        )
+        path = filepath.with_name(str(hash))
 
         entry = {
             "hash": hash,
             "path": str(path),
-            "name": filepath.name,
             "modified_at": modified_at,
         }
-
-        db = self.get_db()
 
         # Add new entry to db with the given hash.
         db[hash] = entry


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature + Bug Fix

## Overview
- Fix attachments having same content but different file name not working properly
- Attachments having same content will never be downloaded twice (even if they have different names, they are in different test cases or steps, etc.)
- Use the hash as the file name so that the probability of collision is always the same as the probability of collision of the hash coming from server.
- Attachments across different servers with same content will never be downloaded twice.