### PR TITLE
Browser metrics

### DIFF
--- a/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
@@ -3463,7 +3463,7 @@ def execute_python_code(data_set):
         elif left == "execute python code":
             Code = right
     Code = filepath_code if filepath_code else Code
-    try: exec(Code, globals())          # Todo: pass only sr.shared_variables and {"sr":sr}
+    try: exec(Code, sr.shared_variables)
     except: return CommonUtil.Exception_Handler(sys.exc_info())
 
     if main_function:

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -854,7 +854,7 @@ def run_test_case(
     try:
         TestCaseStartTime = time.time()
         shared.Set_Shared_Variables("run_id", run_id)
-        test_case = str(TestCaseID).replace("#", "no") # FIXME: Why are we replacing '#' with 'no'?
+        test_case = str(TestCaseID).replace("#", "no")
         CommonUtil.current_tc_no = test_case
         CommonUtil.load_testing = False
         ConfigModule.add_config_value("sectionOne", "sTestStepExecLogId", sModuleInfo, temp_ini_file)
@@ -864,6 +864,8 @@ def run_test_case(
         TestCaseName = testcase_info["title"]
         shared.Set_Shared_Variables("zeuz_current_tc", testcase_info, print_variable=False, pretty=False)
         shared.Set_Shared_Variables("zeuz_auto_teardown", "on")
+        # shared.Set_Shared_Variables("zeuz_automation_log", Path(temp_ini_file).parent.__str__())
+        shared.Set_Shared_Variables("zeuz_attachments_dir", (Path(temp_ini_file).parent/"attachments").__str__())
         if not shared.Test_Shared_Variables("element_wait"):
             shared.Set_Shared_Variables("element_wait", 10)
 

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1588,7 +1588,7 @@ def main(device_dict, user_info_object):
             CommonUtil.upload_on_fail, CommonUtil.rerun_on_fail = send_log_file_only_for_fail, rerun_on_fail
             shared.Set_Shared_Variables("zeuz_auto_teardown", "on")
             global_attachment = GlobalAttachment()
-            shared.Set_Shared_Variables("global_attachements", global_attachment)
+            shared.Set_Shared_Variables("global_attachments", global_attachment)
 
             all_testcases_info = run_id_info["test_cases"]
             TestSetStartTime = time.time()


### PR DESCRIPTION
## Overview
Collect browser performance metrics inside each testcase for each driver_id once when go-to-link is called for the first time

## data structure of report json:
```json
[
  {
    "server_version": "8.0.0",
    "run_id": "Tue-Aug-16-10:18:20-2022",
    "objective": "Practice",
    "project_id": "PROJ-17",
    "team_id": 2,
    "test_cases": [
      {
        "testcase_no": "TEST-3367",
        "title": "muhib browser perf only for gotolink",
        "automatability": "Automated",
        "debug_steps": [],
        "attachments": [],
        "steps": [
          {
            "step_id": 1803,
            "step_name": "only for gotolink",
            "step_sequence": 1,
            "step_driver_type": "Built_In_Driver",
            "automatablity": "automated",
            "always_run": false,
            "run_on_fail": false,
            "step_function": "Sequential Actions",
            "step_driver": "Built_In_Driver",
            "type": "normal",
            "attachments": [],
            "verify_point": false,
            "continue_on_fail": false,
            "step_time": 59,
            "execution_detail": {
              "stepstarttime": "2022-08-16 10:18:24.616353",
              "stependtime": "2022-08-16 10:18:47.477900",
              "end_memory": 2491.078125,
              "duration": "00:00:22.862",
              "memory_consumed": 112.34375,
              "logid": "Tue-Aug-16-10:18:20-2022|TEST-3367|1803|1",
              "status": "Passed"
            }
          }
        ],
        "execution_detail": {
          "teststarttime": "2022-08-16 10:18:24",
          "testendtime": "2022-08-16 10:18:47",
          "duration": "0:00:23",
          "status": "Passed",
          "failreason": "",
          "metrics": {
            "browser_performance": {
              "default": [
                {
                  "Timestamp": 144173.338694,
                  "AudioHandlers": 0,
                  "Documents": 3,
                  "Frames": 2,
                  "JSEventListeners": 16,
                  "LayoutObjects": 57,
                  "MediaKeySessions": 0,
                  "MediaKeys": 0,
                  "Nodes": 311,
                  "Resources": 10,
                  "ContextLifecycleStateObservers": 4,
                  "V8PerContextDatas": 1,
                  "WorkerGlobalScopes": 0,
                  "UACSSResources": 0,
                  "RTCPeerConnections": 0,
                  "ResourceFetchers": 3,
                  "AdSubframes": 0,
                  "DetachedScriptStates": 0,
                  "ArrayBufferContents": 0,
                  "LayoutCount": 3,
                  "RecalcStyleCount": 18,
                  "LayoutDuration": 0.019179,
                  "RecalcStyleDuration": 0.006174,
                  "DevToolsCommandDuration": 0.006422,
                  "ScriptDuration": 0.034327,
                  "V8CompileDuration": 0.000616,
                  "TaskDuration": 0.127686,
                  "TaskOtherDuration": 0.060968,
                  "ThreadTime": 0.125936,
                  "ProcessTime": 0.390625,
                  "JSHeapUsedSize": 4974644,
                  "JSHeapTotalSize": 9531392,
                  "FirstMeaningfulPaint": 144167.755688,
                  "DomContentLoaded": 144168.402698,
                  "NavigationStart": 144165.833192
                }
              ],
              "second": [
                {
                  "Timestamp": 144182.251737,
                  "AudioHandlers": 0,
                  "Documents": 3,
                  "Frames": 2,
                  "JSEventListeners": 16,
                  "LayoutObjects": 57,
                  "MediaKeySessions": 0,
                  "MediaKeys": 0,
                  "Nodes": 311,
                  "Resources": 10,
                  "ContextLifecycleStateObservers": 4,
                  "V8PerContextDatas": 1,
                  "WorkerGlobalScopes": 0,
                  "UACSSResources": 0,
                  "RTCPeerConnections": 0,
                  "ResourceFetchers": 3,
                  "AdSubframes": 0,
                  "DetachedScriptStates": 0,
                  "ArrayBufferContents": 0,
                  "LayoutCount": 3,
                  "RecalcStyleCount": 17,
                  "LayoutDuration": 0.017929,
                  "RecalcStyleDuration": 0.007404,
                  "DevToolsCommandDuration": 0.007479,
                  "ScriptDuration": 0.037424,
                  "V8CompileDuration": 0.000791,
                  "TaskDuration": 0.134504,
                  "TaskOtherDuration": 0.063477,
                  "ThreadTime": 0.135333,
                  "ProcessTime": 0.4375,
                  "JSHeapUsedSize": 4989684,
                  "JSHeapTotalSize": 9531392,
                  "FirstMeaningfulPaint": 144176.69839,
                  "DomContentLoaded": 144177.277608,
                  "NavigationStart": 144174.730979
                }
              ]
            }
          }
        }
      }
    ],
    "dependency_list": {
      "Browser": "ChromeHeadless",
      "Mobile": "Android"
    },
    "device_info": [
      [
        1,
        1
      ]
    ],
    "run_time": {},
    "file_name": "admin_windows_1",
    "runtime_settings": {
      "debug_mode": false,
      "is_linked": false,
      "local_run": false,
      "rerun_on_fail": true,
      "take_screenshot": true,
      "threading": false,
      "upload_log_file_only_for_fail": true,
      "window_size_x": 0,
      "window_size_y": 0
    },
    "debug": "no",
    "debug_clean": "NO",
    "debug_step_actions": [],
    "debug_steps": [],
    "base_path": "TestExecutionLog",
    "execution_detail": {
      "status": "Complete",
      "teststarttime": "2022-08-16 10:18:24",
      "testendtime": "2022-08-16 10:19:01",
      "duration": "0:00:37"
    }
  }
]
```

## Test Cases
- [QA-TEST-3367](https://qa.automationsolutionz.com/Home/ManageTestCases/Edit/TEST-3367/)

