### PR TITLE
Convert 'plus' to '+'

### DIFF
--- a/Framework/Built_In_Automation/Desktop/CrossPlatform/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Desktop/CrossPlatform/BuiltInFunctions.py
@@ -249,7 +249,7 @@ def execute_hotkey(data_set) -> str:
         for left, mid, right in data_set:
             left = left.strip()
             if "hotkey" in left:
-                hotkey_combination = [i.strip() for i in right.split("+")]
+                hotkey_combination = [i.strip().replace("plus", "+") for i in right.split("+")]
             elif "count" in left:
                 try:
                     count = int(right)


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Adds the `plus (+)` hotkey support to pyautogui. This avoids the issue where we cannot use the `+` key because the code splits on the `+` symbol for multiple hotkeys.