### PR TITLE
[Fix] removed outerHTML since it is raising StaleElement error

### DIFF
--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -1481,10 +1481,7 @@ def Click_Element(data_set, retry=0):
                 )
                 return "passed"
             except Exception:
-                element_attributes = Element.get_attribute("outerHTML")
-                CommonUtil.ExecLog(sModuleInfo, "Element Attributes: %s" % (element_attributes), 3)
-                errMsg = "Could not select/click your element."
-                return CommonUtil.Exception_Handler(sys.exc_info(), None, errMsg)
+                return CommonUtil.Exception_Handler(sys.exc_info())
         except StaleElementReferenceException:
             if retry == 5:
                 CommonUtil.ExecLog(sModuleInfo, "Could not perform click because javascript of the element is not fully loaded", 3)
@@ -1494,10 +1491,7 @@ def Click_Element(data_set, retry=0):
             return Click_Element(data_set, retry + 1)
 
         except Exception:
-            element_attributes = Element.get_attribute("outerHTML")
-            CommonUtil.ExecLog(sModuleInfo, "Element Attributes: %s" % (element_attributes), 3)
-            errMsg = "Could not select/click your element."
-            return CommonUtil.Exception_Handler(sys.exc_info(), None, errMsg)
+            return CommonUtil.Exception_Handler(sys.exc_info())
 
     # Click using location
     else:


### PR DESCRIPTION
When the element is stale we cannot call `Element.outerHtml()` function. However we never needed this so just removing