### PR TITLE
Stored error information from log in CommonUtils.py file and wote the…

### DIFF
--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -945,6 +945,9 @@ def run_test_case(
         CommonUtil.action_perf = []
         CommonUtil.step_perf = []
         CommonUtil.global_sleep = {"selenium":{}, "appium":{}, "windows":{}, "desktop":{}}
+
+        # Added this two global variable in CommonUtil to save log information and save filepath of test case report
+        CommonUtil.error_log_info = ""
         # FIXME: Remove these lines
         # import random
         # CommonUtil.d_day = random.randint(1, 4)
@@ -1031,6 +1034,17 @@ def run_test_case(
 
         # Decide if Test Case Pass/Failed
         sTestCaseStatus = calculate_test_case_result(sModuleInfo, test_case, run_id, sTestStepResultList, testcase_info)
+
+        #Writing error information in a text file
+        if sTestCaseStatus == "Failed" or sTestCaseStatus == "Blocked":
+            log_file_path2 = ConfigModule.get_config_value(
+                "sectionOne", "temp_run_file_path", temp_ini_file
+            )
+            run_id_folder2 = str(Path(log_file_path2) / run_id.replace(":", "-"))
+            test_case_folder2 = str(Path(run_id_folder2) / CommonUtil.current_session_name / test_case.replace(":", "-"))
+            with open(test_case_folder2 + '/logerror.txt', 'w') as f:
+                f.write(CommonUtil.error_log_info)
+
 
         # write locust file for performance testing
         if performance:

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1037,11 +1037,7 @@ def run_test_case(
 
         #Writing error information in a text file
         if sTestCaseStatus == "Failed" or sTestCaseStatus == "Blocked":
-            log_file_path2 = ConfigModule.get_config_value(
-                "sectionOne", "temp_run_file_path", temp_ini_file
-            )
-            run_id_folder2 = str(Path(log_file_path2) / run_id.replace(":", "-"))
-            test_case_folder2 = str(Path(run_id_folder2) / CommonUtil.current_session_name / test_case.replace(":", "-"))
+            test_case_folder2 = ConfigModule.get_config_value("sectionOne", "test_case_folder", temp_ini_file)
             with open(test_case_folder2 + '/logerror.txt', 'w') as f:
                 f.write(CommonUtil.error_log_info)
 

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -514,7 +514,7 @@ def ExecLog(
 
     if not print_execlog: return    # For bypass_bug() function dont print logs
 
-    global max_char
+    global max_char, error_log_info
     # Read from settings file
     debug_mode = ConfigModule.get_config_value("RunDefinition", "debug_mode")
 
@@ -647,8 +647,6 @@ def ExecLog(
                 "details": sDetails,
                 "status": status,
                 "loglevel": iLogLevel,
-                "currentaction": current_action_no ,
-                "currentstep": current_step_no,
                 "tstamp": str(now),
             }
             if len(all_logs_list) >= 1:
@@ -679,11 +677,7 @@ def ExecLog(
 
             #saving error information of a log in a global string variable
             if iLogLevel == 3:
-                global error_log_info
-                for zinc in list(all_logs.values()):
-                    if zinc['loglevel'] == 3:
-                        error_log_info += "[STEP-" + str(zinc['currentstep']) + ",ACTION-" + str(zinc['currentaction'])+ \
-                                           "]" + "[" + str(zinc['modulename']) + "] " + str(zinc['details']) + "\n"
+                error_log_info += f"[STEP-{str(current_step_no)} ACTION-{str(current_action_no)}][{sModuleInfo}] {sDetails}\n"
 
 
 

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -99,6 +99,8 @@ all_logs_list = []
 skip_list = ["step_data"]
 to_dlt_from_fail_reason = " : Test Step Failed"
 
+error_log_info = ""
+
 load_testing = False
 performance_report = {"data": [], "individual_stats": {"slowest": 0, "fastest": float("inf")}, "status_counts": {}}
 performance_testing = False
@@ -645,6 +647,8 @@ def ExecLog(
                 "details": sDetails,
                 "status": status,
                 "loglevel": iLogLevel,
+                "currentaction": current_action_no ,
+                "currentstep": current_step_no,
                 "tstamp": str(now),
             }
             if len(all_logs_list) >= 1:
@@ -672,6 +676,16 @@ def ExecLog(
                     all_logs_list.append(all_logs)
                     all_logs_count = 0
                     all_logs = {}
+
+            #saving error information of a log in a global string variable
+            if iLogLevel == 3:
+                global error_log_info
+                for zinc in list(all_logs.values()):
+                    if zinc['loglevel'] == 3:
+                        error_log_info += "[STEP-" + str(zinc['currentstep']) + ",ACTION-" + str(zinc['currentaction'])+ \
+                                           "]" + "[" + str(zinc['modulename']) + "] " + str(zinc['details']) + "\n"
+
+
 
 
 def FormatSeconds(sec):


### PR DESCRIPTION
… error information in a txt file in MainDriverApi file

<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
PR_TYPE


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ * ] Documentation comments have been added / updated.
- [ * ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and server status.


## Overview

Stored error information (if iloglevel is found to be 3) using a global string variable at the end of ExecLog function of Commonutils.py 

Then wrote the information in a txt file if test case status is failed or blocked which will be located inside AutomationLog/ relevant runid/session_1/Test Case ID/ and the txt file will store following log entry parameters
[STEP-id,ACTION-id] [modulename] details
An example is attached below
![Screenshot 2023-04-18 162415](https://user-images.githubusercontent.com/68439779/232749266-4557fd56-284c-43f0-aec0-d3e5906bf62c.png)


