### PR TITLE
Stored the application's process id while launching

### DIFF
--- a/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
@@ -1241,11 +1241,6 @@ def _get_main_window(WindowName):
             TreeScope.Children, Condition.TrueCondition
         )
 
-        NewMainWindowsList = []
-        for i in MainWindowsList:
-            if i.Current.ProcessId in current_pid_list:
-                NewMainWindowsList.append(i)
-
         found_windows = []
         for MainWindowElement in MainWindowsList:
             try:

--- a/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
@@ -403,13 +403,9 @@ def Element_only_search(
 
         )
         all_elements += tmp_elements
-        new_all_elements = []
-        for i in all_elements:
-            if i.Current.ProcessId in current_pid_list:
-                new_all_elements.append(i)
 
-        if new_all_elements:
-            return new_all_elements
+        if all_elements:
+            return all_elements
         else:
             return "zeuz_failed"
 
@@ -1244,7 +1240,13 @@ def _get_main_window(WindowName):
         MainWindowsList = AutomationElement.RootElement.FindAll(
             TreeScope.Children, Condition.TrueCondition
         )
-        for MainWindowElement in MainWindowsList:
+
+        NewMainWindowsList = []
+        for i in MainWindowsList:
+            if i.Current.ProcessId in current_pid_list:
+                NewMainWindowsList.append(i)
+                
+        for MainWindowElement in NewMainWindowsList:
             try:
                 if WindowName[2] == "pid":
                     try:

--- a/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
@@ -383,6 +383,7 @@ def Element_only_search(
 ):
     # max_time is built in wait function.  It will try every seconds 15 times.
     try:
+
         if Parent_Element is not None:
             ParentElement = Parent_Element
             element_index = -1
@@ -402,8 +403,13 @@ def Element_only_search(
 
         )
         all_elements += tmp_elements
-        if all_elements:
-            return all_elements
+        new_all_elements = []
+        for i in all_elements:
+            if i.Current.ProcessId in current_pid_list:
+                new_all_elements.append(i)
+
+        if new_all_elements:
+            return new_all_elements
         else:
             return "zeuz_failed"
 
@@ -1712,6 +1718,7 @@ def Run_Application(data_set):
                 subprocess.Popen(cmd, **args)
                 # Desktop_app = os.path.basename(Desktop_app)
             else:
+                #last_start_time = time.time()
                 autoit.send("^{ESC}")
                 time.sleep(0.5)
                 autoit.send(Desktop_app)

--- a/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
@@ -36,6 +36,7 @@ from PIL import Image, ImageGrab
 
 
 python_folder = []
+current_pid_list = []
 for location in subprocess.getoutput("where python").split("\n"):
     if "Microsoft" not in location:
         python_folder.append(location)
@@ -1658,6 +1659,8 @@ def _open_inspector(inspector, args):
 @logger
 def Run_Application(data_set):
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global current_pid_list
+    current_pid_list = []
     try:
         args = {"shell": True, "stdin": None, "stdout": None, "stderr": None}
         launch_cond = ""
@@ -1721,6 +1724,10 @@ def Run_Application(data_set):
             #     Desktop_app += ".exe"
             CommonUtil.ExecLog(sModuleInfo, "Waiting for the app to launch for maximum %s seconds" % wait, 1)
             s = time.time()
+            for process in psutil.process_iter(['pid', 'name']):
+                if Desktop_app.lower() in process.info['name'].lower():
+                    current_pid_list.append(process.info['pid'])
+
             while time.time() - s < wait:
                 # if len(pygetwindow.getWindowsWithTitle(Desktop_app)) > 0:     # This is case in-sensitive
                 if pygetwindow.getActiveWindow() is None or Desktop_app in pygetwindow.getActiveWindow().title:          # This is case sensitive
@@ -1732,7 +1739,6 @@ def Run_Application(data_set):
                 else:
                     CommonUtil.ExecLog(sModuleInfo, "Could not find any launched app with title: %s however continuing" % Desktop_app, 2)
                 return "passed"
-
         if maximize:
             win = pygetwindow.getWindowsWithTitle(Desktop_app)[0]
             win.maximize()

--- a/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
@@ -1245,8 +1245,9 @@ def _get_main_window(WindowName):
         for i in MainWindowsList:
             if i.Current.ProcessId in current_pid_list:
                 NewMainWindowsList.append(i)
-                
-        for MainWindowElement in NewMainWindowsList:
+
+        found_windows = []
+        for MainWindowElement in MainWindowsList:
             try:
                 if WindowName[2] == "pid":
                     try:
@@ -1257,12 +1258,19 @@ def _get_main_window(WindowName):
                 else:
                     NameS = MainWindowElement.Current.Name
                     if _found(WindowName, NameS):
-                        CommonUtil.ExecLog(sModuleInfo, "Switching to window: %s" % NameS, 1)
-                        autoit.win_activate(NameS)
-                        return MainWindowElement
+                        if MainWindowElement.Current.ProcessId in current_pid_list:
+                            CommonUtil.ExecLog(sModuleInfo, "Switching to window: %s" % NameS, 1)
+                            CommonUtil.ExecLog(sModuleInfo, f"pid matched: {MainWindowElement.Current.ProcessId}", 5)
+                            autoit.win_activate(NameS)
+                            return MainWindowElement
+                        else:
+                            found_windows.append(MainWindowElement)
             except:
                 pass
-
+        if len(found_windows) > 0:
+            CommonUtil.ExecLog(sModuleInfo, "Switching to window: %s" % found_windows[0].Current.Name, 1)
+            autoit.win_activate(found_windows[0].Current.Name)
+            return found_windows[0]
         return None
     except Exception:
         CommonUtil.Exception_Handler(sys.exc_info())


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!--Feature -->
PR_TYPE


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [x] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
Able to store a windows application process id(s) while launching the application and then checking if AutomationElement is tracking any other process using those stored process id(s) so that automation scope focuses on only the desired application

## Test Cases
- [TEST-6904](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-6904/#parentHorizontalTab2)

