### PR TITLE
Disable live log

### DIFF
--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -260,7 +260,9 @@ def prettify(key, val):
             print(json.dumps(val,indent=2)[:prettify_limit])
 
         expression = "%s = %s" % (key, json.dumps(val, indent=2, sort_keys=True)[:prettify_limit])
-        if debug_status and key not in dont_prettify_on_server and ws_ss_log:
+        stop_live_log = ConfigModule.get_config_value("Advanced Options", "stop_live_log")
+
+        if debug_status and key not in dont_prettify_on_server and ws_ss_log and stop_live_log == 'False':
             live_log_service.log("VARIABLE", 4, expression.replace("\n", "<br>").replace(" ", "&nbsp;"))
             # 4 means console log which is Magenta color in server console
     except:
@@ -582,7 +584,9 @@ def ExecLog(
     # Set current log as the next previous log
     previous_log_line = current_log_line
 
-    if debug_status and ws_ss_log:
+    stop_live_log = ConfigModule.get_config_value("Advanced Options", "stop_live_log")
+
+    if debug_status and ws_ss_log and stop_live_log == 'False':
         live_log_service.log(sModuleInfo, iLogLevel, sDetails)
 
     if iLogLevel > 0:

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -586,7 +586,7 @@ def ExecLog(
 
     stop_live_log = ConfigModule.get_config_value("Advanced Options", "stop_live_log")
 
-    if debug_status and ws_ss_log and stop_live_log == 'False':
+    if debug_status and ws_ss_log and stop_live_log.strip().lower() in ('false', 'no', 'disable'):
         live_log_service.log(sModuleInfo, iLogLevel, sDetails)
 
     if iLogLevel > 0:

--- a/Framework/settings.conf
+++ b/Framework/settings.conf
@@ -1,8 +1,8 @@
 [Authentication]
 server_address = https://zeuz.zeuz.ai
-username = tareq
+username = 
 password = 
-api-key = bfdfd1d9-9cf2-466f-8651-581840e8e7f2
+api-key = 
 
 [Advanced Options]
 element_wait = 10

--- a/Framework/settings.conf
+++ b/Framework/settings.conf
@@ -1,8 +1,8 @@
 [Authentication]
 server_address = https://zeuz.zeuz.ai
-username =
-password =
-api-key =
+username = tareq
+password = 
+api-key = bfdfd1d9-9cf2-466f-8651-581840e8e7f2
 
 [Advanced Options]
 element_wait = 10
@@ -10,6 +10,7 @@ available_to_all_project = False
 _file = temp_config.ini
 _file_upload_path = TestExecutionLog
 log_delete_interval = 30
+stop_live_log = True
 
 [Selenium_driver_paths]
 chrome_path = 

--- a/node_cli.py
+++ b/node_cli.py
@@ -980,6 +980,10 @@ def command_line_args() -> Path:
         "-sbl", "--show_browser_log", action="store_true", help="Show browserlog in the console"
     )
 
+    parser_object.add_argument(
+        "-slg", "--stop_live_log", action="store_true", help="Disables log in live server"
+    )
+
     all_arguments = parser_object.parse_args()
 
     username = all_arguments.username
@@ -993,6 +997,7 @@ def command_line_args() -> Path:
     gh_token = all_arguments.gh_token
     stop_pip_auto_update = all_arguments.stop_pip_auto_update
     show_browser_log = all_arguments.show_browser_log
+    stop_live_log = all_arguments.stop_live_log
 
     # Check if custom log directory exists, if not, we'll try to create it. If
     # we can't create the custom log directory, we should error out.
@@ -1111,6 +1116,8 @@ def command_line_args() -> Path:
         pass
     if gh_token:
         os.environ["GH_TOKEN"] = gh_token
+
+    ConfigModule.add_config_value("Advanced Options", "stop_live_log", str(stop_live_log))
 
     """argparse module automatically shows exceptions of corresponding wrong arguments
      and executes sys.exit(). So we don't need to use try except"""


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature 


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated. 
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and server status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

A new flag has been added "-slg". When we use this flag we will not see any logs in the live server. This flag affects the ExecLog and live_log_service.log functions. If we use the "-slg" flag live_log_service.log function should be disabled resulting no log in the server. To use this flag we have to write following command

python node_cli.py -slg

## Test Cases
- [TEST-0000](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-0000/)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
