### PR TITLE
browser profile addition for Chrome, Edge and Firefox

### DIFF
--- a/Framework/Built_In_Automation/Sequential_Actions/action_declarations/info.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/action_declarations/info.py
@@ -85,6 +85,7 @@ action_support = (
     "graphql",
     "shared capability",
     "chrome option", "chrome options", "chrome experimental option", "chrome experimental options",
+    "profile option", "profile options",
     "pre sleep", "post sleep", "pre post sleep", "post pre sleep"
 )
 patterns = [

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -560,15 +560,14 @@ def Open_Browser(dependency, window_size_X=None, window_size_Y=None, capability=
         browser_map = {
             "microsoft edge chromium": 'msedge',
             "chrome": "chrome",
-            "fireFox": "firefox",
             "firefox": "firefox",
-            "chromeHeadless": "chrome",
-            "firefoxHeadless": "firefox",
-            "edgeChromiumHeadless": "msedge",
+            "chromeheadless": "chrome",
+            "firefoxheadless": "firefox",
+            "edgechromiumheadless": "msedge",
         }
 
         if profile_options:
-            if browser in browser_map.keys():
+            if browser.strip().lower() in browser_map.keys():
                 browser_short_form = browser_map[browser] 
                 process_status = browser_process_status(browser_short_form)
                 for options in profile_options:
@@ -593,6 +592,10 @@ def Open_Browser(dependency, window_size_X=None, window_size_Y=None, capability=
                     if kill_output_status == "SUCCESS:":
                         CommonUtil.ExecLog(
                             sModuleInfo, f"Successfully terminated all the {browser_short_form}.exe processes", 1
+                        )
+                    else:
+                        CommonUtil.ExecLog(
+                            sModuleInfo, f"Could not terminate the {browser_short_form}.exe processes", 3
                         )
             else:
                 CommonUtil.ExecLog(


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [x] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Added a new optional parameter in the `Framework\Built_In_Automation\Sequential_Actions\action_declarations\info.py` file named `profile option, profile options`

Declared a new empty list named "profile_options" that will hold the values for add_argument options

```python
profile_options = []

elif mid.strip().lower() in ("profile option", "profile options"):
    profile_options.append([left, right.strip()])
```
We will pass the "profile_options" list to the Open_Browser function

`result = Open_Browser(dependency, capability=capabilities, browser_options=browser_options, profile_options=profile_options)`

Added a function called "browser_process_status" that will check if the browser is running in the background or not
If it returns True that means the browser process is running else it should return False

```python
def browser_process_status(browser:str):
    list_process_command = ['tasklist']
    seacrh_command = ['findstr', f'{browser}.exe']

    list_process = subprocess.Popen(list_process_command, stdout=subprocess.PIPE)
    search_process = subprocess.Popen(seacrh_command, stdin=list_process.stdout, stdout=subprocess.PIPE, text=True)

    output,_ = search_process.communicate()

    if output:
        return True
    else:
        return False
```

Then we will check if Zeuz supporsts browser profile option for that specific browser

```python
browser_map = {
            "microsoft edge chromium": 'msedge',
            "chrome": "chrome",
            "fireFox": "firefox",
            "firefox": "firefox",
            "chromeHeadless": "chrome",
            "firefoxHeadless": "firefox",
            "edgeChromiumHeadless": "msedge",
        }

        if profile_options:
            if browser in browser_map.keys():
                ...
        else:
            CommonUtil.ExecLog(
                    sModuleInfo, f"ZeuZ does not support browser profile for {browser} browser", 3
                )
            raise Exception}
```

Then we will check if the "auto kill for profile option" has been mentioned or not.
If mentioned True then we will set the "kill_process" variable to True which is by default False

```python
for options in profile_options:
    if options[0] == "autokillforprofile" and options[1] == "True":
        kill_process = True
```

If the browser is currently running and the "auto kill for profile option" has not been set to True we will raise an exception with a message

```python
if process_status == True and kill_process == False:
    err_msg = f'''
    Please close all the {browser} browser instance.
    Or, use the following optional parameter to do it automatically:
    ( auto kill for profile | browser option | True )
    '''
    CommonUtil.ExecLog(
        sModuleInfo, err_msg, 3
    )
    raise Exception
```

Else if the browser is running and the "auto kill for profile option" has been set to True we will close all the processes first

```python
elif process_status == True and kill_process == True:
    task_kill_command = ['taskkill', '/IM', f'{browser_short_form}.exe', '/F']
    task_kill_process = subprocess.Popen(task_kill_command, stdout=subprocess.PIPE, text=True)
    kill_output,err = task_kill_process.communicate()
    kill_output_status = kill_output.split()[0]
    if kill_output_status == "SUCCESS:":
        CommonUtil.ExecLog(
            sModuleInfo, f"Successfully terminated all the {browser_short_form}.exe processes", 1
        )
```

Finally we will add the profiles to the browser options accordingly

```python
if profile_options:
    for left, right in profile_options:
        if left in ("addargument", "addarguments"):
            options.add_argument(right.strip())
            print(left, right)
```

## Test Cases
- [TEST-6975](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-6975/)
- [TEST-6976](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-6976/)
- [TEST-6977](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-6977/)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
