### PR TITLE
Changed the outdated module distutils and replaced it with shutil whi…

### DIFF
--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -2098,7 +2098,7 @@ def main(device_dict, user_info_object):
                 print("Test Set Cancelled by the User")
             elif not CommonUtil.debug_status:
 
-                from distutils.dir_util import copy_tree
+                from shutil import copytree
 
                 # If node is running in device farm, copy the logs and reports to the expected directory.
                 if "DEVICEFARM_LOG_DIR" in os.environ:
@@ -2107,7 +2107,7 @@ def main(device_dict, user_info_object):
                         "sectionOne", "test_case_folder", temp_ini_file
                     )).parent
 
-                    copy_tree(str(zeuz_log_dir), str(log_dir))
+                    copytree(str(zeuz_log_dir), str(log_dir))
 
                 # Telling the node_manager that a run_id is finished
                 CommonUtil.node_manager_json(


### PR DESCRIPTION
…ch has the same functionality as previous and is used in latest python versions

<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
Bug Fix 
PR_TYPE


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [x] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
Changed outdated distutils module which was removed in python 3.12 and replaced it with shutil module which does the same thing. Replaced distutils copy_tree() function with shutil copytree() which does the same thing and is not outdated in latest python versions as well
<!-- Emphasize any breaking changes. -->

## Test Cases
- [TEST-6974](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-6974/)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
