### PR TITLE
[wip] Add zoom and pan

### DIFF
--- a/Framework/Built_In_Automation/Built_In_Utility/CrossPlatform/BuiltInUtilityFunction.py
+++ b/Framework/Built_In_Automation/Built_In_Utility/CrossPlatform/BuiltInUtilityFunction.py
@@ -2302,11 +2302,13 @@ def compare_images(data_set):
     This action compares two given images. At first, both the images are resized into same width
     and height (min width and height from either image) and then both of them are converted into
     grayscale images. Next, structural similarity is computed and compared with the given score.
+    The similarity score can be accessed via the 'score' variable. You can also provide the
+    variable name as desire e.g 'score1'/'final_score' etc
 
     :param data_set:
-        [['/path/to/a.png',  'compare',              '/path/to/b.png'],
-        ['min match score', 'element parameter',    '0.75'],
-        ['compare images',  'utility action',       'none']]
+        [['/path/to/a.png',     'compare',              '/path/to/b.png'],
+        ['min match score',     'element parameter',    '0.75'],
+        ['compare images',      'utility action',       'score']]
     :return: "passed" if both images match within the given matching score percentage
     """
 

--- a/Framework/Built_In_Automation/Built_In_Utility/CrossPlatform/BuiltInUtilityFunction.py
+++ b/Framework/Built_In_Automation/Built_In_Utility/CrossPlatform/BuiltInUtilityFunction.py
@@ -2314,6 +2314,7 @@ def compare_images(data_set):
     CommonUtil.ExecLog(sModuleInfo, "Function: compare images", 0)
 
     try:
+        # try to import the 'skimage' library. If 'skimage' library is not installed then install_missing_modules will install it
         try:
             import skimage, cv2, imutils
             from skimage.metrics import structural_similarity as ssim

--- a/Framework/Built_In_Automation/Built_In_Utility/CrossPlatform/BuiltInUtilityFunction.py
+++ b/Framework/Built_In_Automation/Built_In_Utility/CrossPlatform/BuiltInUtilityFunction.py
@@ -2314,8 +2314,16 @@ def compare_images(data_set):
     CommonUtil.ExecLog(sModuleInfo, "Function: compare images", 0)
 
     try:
-        import skimage, cv2, imutils
-        from skimage.metrics import structural_similarity as ssim
+        try:
+            import skimage, cv2, imutils
+            from skimage.metrics import structural_similarity as ssim
+        except:
+            from Framework.module_installer import install_missing_modules
+            install_missing_modules(['scikit-image'])
+            import skimage, cv2, imutils
+            from skimage.metrics import structural_similarity as ssim
+
+        score = 'score'
 
         default_ssim = float(1)
 
@@ -2334,6 +2342,8 @@ def compare_images(data_set):
                     user_ssim = float(
                         eachrow[2]
                     )  # User defined minimum match score (i.e. SSIM)
+            elif 'action' in eachrow[1]:
+                score = eachrow[2].strip()
 
         imageA = cv2.imread(imageA_path)  # Read first image
         imageB = cv2.imread(imageB_path)  # Read second image
@@ -2404,6 +2414,8 @@ def compare_images(data_set):
             req_ssim = default_ssim
 
         # Perform the image comparison based on the structural similarity index
+
+        Shared_Resources.Set_Shared_Variables(score, ssim_match)
         if ssim_match >= req_ssim:
             CommonUtil.ExecLog(sModuleInfo, "Images match", 1)
             return "passed"

--- a/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
@@ -920,7 +920,7 @@ def start_appium_driver(
             count = 1
             while count <= 5:
                 try:
-                    appium_driver = webdriver.Remote("http://localhost:%d/wd/hub" % appium_port, desired_caps)  # Create instance
+                    appium_driver = webdriver.Remote("http://localhost:%d" % appium_port, desired_caps)  # Create instance
                     if appium_driver:
                         break
                     count += 1
@@ -4632,10 +4632,20 @@ def zoom_action(data_set):
 
     global appium_driver
 
-    xs = 0
-    xe = int(appium_driver.get_window_size()['width'])
-    xx = appium_driver.get_window_size()['width']//2
-    yy = appium_driver.get_window_size()['height']//2
+    zoom_element = LocateElement.Get_Element(data_set, appium_driver)
+    if zoom_element == "zeuz_failed":
+        CommonUtil.ExecLog(sModuleInfo, "Zoom element is not found", 3)
+        return "zeuz_failed"
+    
+    height = zoom_element.size["height"]
+    width = zoom_element.size["width"]
+    xstart_location = zoom_element.location["x"]
+    ystart_location = zoom_element.location["y"]
+    xx = xstart_location+int((width)//2)
+    yy = ystart_location+int((height)//2)
+
+    xs = xstart_location
+    xe = xstart_location+width  
 
     action = ''
     scale = 3
@@ -4678,8 +4688,8 @@ def zoom_action(data_set):
                 if x_cord2:
                     xe = x_cord2
 
-                action1.long_press(x=xs+const, y=yy).move_to(x=xs+(const*1*scale), y=yy).move_to(x=xs+(const*2*scale), y=yy).move_to(x=xs+(const*3*scale), y=yy).release()
-                action2.long_press(x=xe-const, y=yy).move_to(x=xe-(const*1*scale), y=yy).move_to(x=xe-(const*2*scale), y=yy).move_to(x=xe-(const*3*scale), y=yy).release()
+                action1.long_press(x=xs+const, y=yy).move_to(x=xs+(const*1*scale), y=yy).move_to(x=xs+int((const*1.5*scale)), y=yy).move_to(x=xs+(const*2*scale), y=yy).move_to(x=xs+int((const*2.5*scale)), y=yy).move_to(x=xs+(const*3*scale), y=yy).release()
+                action2.long_press(x=xe-const, y=yy).move_to(x=xe-(const*1*scale), y=yy).move_to(x=xe-int((const*1.5*scale)), y=yy).move_to(x=xe-(const*2*scale), y=yy).move_to(x=xe-int((const*2.5*scale)), y=yy).move_to(x=xe-(const*3*scale), y=yy).release()
                 m_action.add(action1, action2)
                 m_action.perform()      
                 time.sleep(2) 
@@ -4693,8 +4703,8 @@ def zoom_action(data_set):
                     xx2 = x_cord2
 
                 if double_tap == False:
-                    action1.long_press(x=xx1, y=yy).move_to(x=xx1-(const*1*scale), y=yy).move_to(x=xx1-(const*2*scale), y=yy).move_to(x=xx1-(const*3*scale), y=yy).release()
-                    action2.long_press(x=xx2, y=yy).move_to(x=xx2+(const*1*scale), y=yy).move_to(x=xx2+(const*2*scale), y=yy).move_to(x=xx+(const*3*scale), y=yy).release()
+                    action1.long_press(x=xx1, y=yy).move_to(x=xx1-(const*1*scale), y=yy).move_to(x=xx1-int((const*1.5*scale)), y=yy).move_to(x=xx1-(const*2*scale), y=yy).move_to(x=xx1-int((const*2.5*scale)), y=yy).move_to(x=xx1-(const*3*scale), y=yy).release()
+                    action2.long_press(x=xx2, y=yy).move_to(x=xx2+(const*1*scale), y=yy).move_to(x=xx2+int((const*1.5*scale)), y=yy).move_to(x=xx2+(const*2*scale), y=yy).move_to(x=xx2+int((const*2.5*scale)), y=yy).move_to(x=xx2+(const*3*scale), y=yy).release()
                     m_action.add(action1, action2)
                     m_action.perform()      
                     time.sleep(2)  
@@ -4722,8 +4732,18 @@ def pan_action(data_set):
 
     global appium_driver
 
-    xx = appium_driver.get_window_size()['width']//2
-    yy = appium_driver.get_window_size()['height']//2
+    zoom_element = LocateElement.Get_Element(data_set, appium_driver)
+    if zoom_element == "zeuz_failed":
+        CommonUtil.ExecLog(sModuleInfo, "Zoom element is not found", 3)
+        return "zeuz_failed"
+    
+    height = zoom_element.size["height"]
+    width = zoom_element.size["width"]
+    xstart_location = zoom_element.location["x"]
+    ystart_location = zoom_element.location["y"]
+    xx = xstart_location+int((width)//2)
+    yy = ystart_location+int((height)//2)
+
     const = 75
 
     direction = ''

--- a/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
@@ -4655,22 +4655,15 @@ def zoom_action(data_set):
 
     xx1 = xx-const
     xx2 = xx+const
-    x_cord1 = None
-    x_cord2 = None
-
 
     try:
         for left, mid, right in data_set:
             if left.strip().lower() == 'action':
-                action = right.strip().lower().replace(' ','')
+                action = right.lower().replace(' ','')
             elif left.strip().lower() == 'scale':
                 scale = int(right)
             elif left.strip().lower() == 'count':
                 count = int(right)
-            elif 'coordinates' in left.strip().lower():
-                cords = right.strip()
-                x_cord1 = int(cords[0].replace('(',''))
-                x_cord2 = int(cords[1].replace(')',''))
             elif left.strip().lower() == 'double tap':
                 double_tap = right.strip().lower() in ('true', 'enable', 'ok', 'yes')
         
@@ -4682,10 +4675,6 @@ def zoom_action(data_set):
         if action == 'zoomout':
             for i in range(count):   
                 CommonUtil.ExecLog(sModuleInfo, f"Zoomed {i+1} time", 1) 
-                if x_cord1:
-                    xs = x_cord1
-                if x_cord2:
-                    xe = x_cord2
 
                 action1.long_press(x=xs+const, y=yy).move_to(x=xs+(const*1*scale), y=yy).move_to(x=xs+int((const*1.5*scale)), y=yy).move_to(x=xs+(const*2*scale), y=yy).move_to(x=xs+int((const*2.5*scale)), y=yy).move_to(x=xs+(const*3*scale), y=yy).release()
                 action2.long_press(x=xe-const, y=yy).move_to(x=xe-(const*1*scale), y=yy).move_to(x=xe-int((const*1.5*scale)), y=yy).move_to(x=xe-(const*2*scale), y=yy).move_to(x=xe-int((const*2.5*scale)), y=yy).move_to(x=xe-(const*3*scale), y=yy).release()
@@ -4696,10 +4685,6 @@ def zoom_action(data_set):
         elif action == 'zoomin':
             for i in range(count):    
                 CommonUtil.ExecLog(sModuleInfo, f"Zoomed {i+1} time", 1)
-                if x_cord1:
-                    xx1 = x_cord1
-                if x_cord2:
-                    xx2 = x_cord2
 
                 if double_tap == False:
                     action1.long_press(x=xx1, y=yy).move_to(x=xx1-(const*1*scale), y=yy).move_to(x=xx1-int((const*1.5*scale)), y=yy).move_to(x=xx1-(const*2*scale), y=yy).move_to(x=xx1-int((const*2.5*scale)), y=yy).move_to(x=xx1-(const*3*scale), y=yy).release()
@@ -4752,7 +4737,7 @@ def pan_action(data_set):
     try:
         for left, mid, right in data_set:
             if left.strip().lower() == 'direction':
-                direction = right.strip().lower().replace(' ','')
+                direction = right.lower().replace(' ','')
             elif left.strip().lower() == 'scale':
                 scale = int(right)
             elif left.strip().lower() == 'count':

--- a/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
@@ -4672,8 +4672,7 @@ def zoom_action(data_set):
                 x_cord1 = int(cords[0].replace('(',''))
                 x_cord2 = int(cords[1].replace(')',''))
             elif left.strip().lower() == 'double tap':
-                if right.strip().lower() == 'true':
-                    double_tap = True
+                double_tap = right.strip().lower() in ('true', 'enable', 'ok', 'yes')
         
         action1 = TouchAction(appium_driver)
         action2 = TouchAction(appium_driver)

--- a/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
@@ -1840,7 +1840,8 @@ def add_media_ios(data_set):
 def take_screenshot_appium(data_set):
     """
     Data set:
-    take screenshot     appium action           filename_format
+    'filename'            'optional option'         'image1.jpg'
+    'take screenshot'     'appium action'           'screenshot_folder'
 
     The filename of the saved screenshot will be stored in the "zeuz_screenshot"
     """
@@ -4620,7 +4621,12 @@ def scroll_to_element(data_set):
 
 def zoom_action(data_set):
     """
-    This function is used for zoom in or zoom out
+    This function is used for zoom in or zoom out. The scale and count parameters controls the amount of zoom.
+    :param data_set:
+        [['Action',         'zoom parameter',       'zoom in'/'zoom out'],
+        ['Scale',           'zoom parameter',        3],
+        ['Count',           'zoom parameter',        5],
+        ['zoom',            'appium action',        'Zoom in or out']]
     """        
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
 
@@ -4705,7 +4711,12 @@ def zoom_action(data_set):
 
 def pan_action(data_set):
     """
-    This function is used for pan
+    This function is used for pan. The scale and count parameters controls the amount of pan.
+    :param data_set:
+        [['direction',      'pan parameter',       'right'/'left'/'up'/'down'],
+        ['Scale',           'pan parameter',        3],
+        ['Count',           'pan parameter',        5],
+        ['pan',             'appium action',       'Pan in a direction']]
     """        
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
 

--- a/Framework/Built_In_Automation/Sequential_Actions/action_declarations/appium.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/action_declarations/appium.py
@@ -50,6 +50,8 @@ declarations = (
     { "name": "go to webpage",            "function": "go_to_webpage",               "screenshot": "mobile" },
     { "name": "save attribute values in list", "function": "save_attribute_values_appium", "screenshot": "mobile"},
     { "name": "seek progress bar",        "function": "Seek_Progress_Bar",           "screenshot": "mobile"},
+    { "name": "zoom",                     "function": "zoom_action",                 "screenshot": "mobile"},
+    { "name": "pan",                      "function": "pan_action",                  "screenshot": "mobile"},
 ) # yapf: disable
 
 module_name = "appium"

--- a/Framework/Built_In_Automation/Sequential_Actions/action_declarations/info.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/action_declarations/info.py
@@ -85,7 +85,8 @@ action_support = (
     "graphql",
     "shared capability",
     "chrome option", "chrome options", "chrome experimental option", "chrome experimental options",
-    "pre sleep", "post sleep", "pre post sleep", "post pre sleep"
+    "pre sleep", "post sleep", "pre post sleep", "post pre sleep",
+    "zoom parameter", "optional zoom parameter", "pan parameter", "optional pan parameter"
 )
 patterns = [
     "^parent \d parameter$",


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [X] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Have added two new functions in `Framework\Built_In_Automation\Mobile\CrossPlatform\Appium\BuiltInFunctions.py` the functions are `zoom_action` and `pan_action`

The `zoom_action` function will enable zoom in and zoom out for Android devices

The `pan_action` function will pan left/right/up/down for Android devices

Also have updated the `take_screenshot_appium` function. Previously the screenshot's name was saved as a timestamp of the moment the screenshot was taken. But now we can provide a name as an optional option parameter. We can also access the location of the `screen_capture_folder` by providing a variable name in appium action. The default variable is 'ss_path'

```python
filename = None
    var_name = 'ss_path'

for left, mid, right in data_set:
        if left.strip().lower() == 'filename':
            filename = right.strip().lower()
        elif 'action' in mid.strip().lower():
            var_name = right.strip()

if filename == None:
        filename_format = "%Y_%m_%d_%H-%M-%S"
        filename = time.strftime(filename_format) + ".png"
Shared_Resources.Set_Shared_Variables(var_name, screenshot_folder)
```

Also updated the `compare_images` function. The 'skimage' library will only get installed if we call the  `compare_images` function. Also we can access the score of similarity by using the 'score' variable. We can also set the variable name in 'utility action' row

```python
 try:
        import skimage, cv2, imutils
        from skimage.metrics import structural_similarity as ssim
 except:
        from Framework.module_installer import install_missing_modules
        install_missing_modules(['scikit-image'])
        import skimage, cv2, imutils
        from skimage.metrics import structural_similarity as ssim
```

## Test Cases
- [TEST-7010](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-7010/)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
