### PR TITLE
Add `body` and `basic: auth` support for http get action

### DIFF
--- a/Framework/Built_In_Automation/Web/REST/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/REST/BuiltInFunctions.py
@@ -751,6 +751,7 @@ def handle_rest_call(
     allow_redirects=True,
     cert=None,
     print_output=True,
+    auth=None,
 ):
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     try:
@@ -872,6 +873,8 @@ def handle_rest_call(
                     method=method,
                     url=url,
                     headers=headers,
+                    json=body,
+                    auth=auth,
                     verify=False,
                     timeout=timeout,
                     allow_redirects=allow_redirects,
@@ -1182,6 +1185,7 @@ def Get_Response(step_data, save_cookie=False):
         allow_redirects = True
         cert = None
         print_output = True
+        auth = None
 
         for left, mid, right in step_data:
             left = left.lower()
@@ -1210,6 +1214,8 @@ def Get_Response(step_data, save_cookie=False):
                 allow_redirects = True if "true" in right.lower() else False
             elif "print output" in left:
                 print_output = True if "true" in right.lower() else False
+            elif "auth: basic" in left:
+                auth = tuple(right.split(":"))
 
         element_step_data = Get_Element_Step_Data(step_data)
 
@@ -1230,6 +1236,7 @@ def Get_Response(step_data, save_cookie=False):
                     allow_redirects=allow_redirects,
                     cert=cert,
                     print_output=print_output,
+                    auth=auth,
                 )
                 return return_result
             except Exception:


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [x] Required modules have been added to respective "requirements*.txt" files.
- [x] Relevant Test Cases added to this description (below).
- [x] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
- Adds support for providing `body` in GET requests.
- Adds support for providing `auth: basic` in GET requests. Usernames
   and passwords are separated by a colon - `:`.

Example:
```
plain text     | body                         | anything here
auth: basic  | optional parameter  | username:password
```

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
