### PR TITLE
fixed desktop actions access attached files and print image match score

### DIFF
--- a/Framework/Built_In_Automation/Built_In_Utility/CrossPlatform/BuiltInUtilityFunction.py
+++ b/Framework/Built_In_Automation/Built_In_Utility/CrossPlatform/BuiltInUtilityFunction.py
@@ -2419,6 +2419,7 @@ def compare_images(data_set):
         # Perform the image comparison based on the structural similarity index
 
         Shared_Resources.Set_Shared_Variables(score, ssim_match)
+        print('Score:',ssim_match)
         if ssim_match >= req_ssim:
             CommonUtil.ExecLog(sModuleInfo, "Images match", 1)
             return "passed"

--- a/Framework/Built_In_Automation/Shared_Resources/LocateElement.py
+++ b/Framework/Built_In_Automation/Shared_Resources/LocateElement.py
@@ -1134,8 +1134,8 @@ def _pyautogui(step_data_set):
 
     # Recall file attachment, if not already set
     file_attachment = []
-    if sr.Test_Shared_Variables("file_attachment"):
-        file_attachment = sr.Get_Shared_Variables("file_attachment")
+    if sr.attachment_variables:
+        file_attachment = sr.attachment_variables
 
     # Parse data set
     try:
@@ -1171,6 +1171,8 @@ def _pyautogui(step_data_set):
         # Check that we have some value
         if file_name == "":
             return "zeuz_failed"
+        
+
 
         # Try to find the image file
         if file_name not in file_attachment and not os.path.exists(file_name):


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

In the case of running desktop actions got an error saying the image was not found locally

![image_not_found](https://github.com/AutomationSolutionz/Zeuz_Python_Node/assets/47948901/3e8438cd-304b-4b8a-9112-70d9f98f9a40)

Investigated the issue and found that the program was not able to access the attached images. So I changed the code for `Framework\Built_In_Automation\Shared_Resources\LocateElement.py`

The previous code was 
```
if sr.Test_Shared_Variables("file_attachment"):
        file_attachment = sr.Get_Shared_Variables("file_attachment")
```

Here there was no such key named "file_attachment" in BuiltInFunctionSharedResources. So changed it to the following

```
if sr.attachment_variables:
        file_attachment = sr.attachment_variables
```

## Test Cases
- [TEST-0000](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-0000/)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
