### PR TITLE
no age shaming

### DIFF
--- a/Apps/Web/AI_Recorder/manifest.json
+++ b/Apps/Web/AI_Recorder/manifest.json
@@ -3,7 +3,7 @@
     "manifest_version": 3,
     "name": "ZeuZ Test Recorder",
     "version": "3.0",
-    "minimum_chrome_version": "117",
+    "minimum_chrome_version": "1",
     "icons": {
         "16": "panel/assets/images/small_logo.png",
         "48": "panel/assets/images/small_logo.png",


### PR DESCRIPTION
users of old browsers might not use browser extensions or know what they are doing. if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 117 > Number(navigator.userAgent.match(new RegExp(Chrome|Firefox + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 117+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by its button or storage change.)
