### PR TITLE
Appium port fix

### DIFF
--- a/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
@@ -662,6 +662,7 @@ def start_appium_server():
         while is_port_in_use(appium_port) and tries < 20:
             appium_port += 2
             wdaLocalPort += 2
+            tries += 1
 
         if tries >= 20:
             CommonUtil.ExecLog(

--- a/Framework/Utilities/decorators.py
+++ b/Framework/Utilities/decorators.py
@@ -14,11 +14,14 @@ def logger(func):
         custom_fail_message = ""
         result = func(*args, **kwargs)
         if result in failed_tag_list:
-            for row in args[0]:
-                if row[1].replace(" ", "").lower() == "failmessage":
-                    custom_fail_message = row[2]
-            # Todo: print the custom_fail_message
-            CommonUtil.ExecLog(None, custom_fail_message, 3)
+            try:
+                for row in args[0]:
+                    if row[1].replace(" ", "").lower() == "failmessage":
+                        custom_fail_message = row[2]
+                # Todo: print the custom_fail_message
+                CommonUtil.ExecLog(None, custom_fail_message, 3)
+            except:
+                pass
         end_time = time.perf_counter()
         run_time = end_time - start_time
 


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
PR_TYPE
Bug Fix

## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Added `tries += 1` in the following code, otherwise it would have looked for an open port infinitely. But now it will look for an open port for 20 times.

```
appium_port = 4723
wdaLocalPort = 8100
tries = 0
while is_port_in_use(appium_port) and tries < 20:
            appium_port += 2
            wdaLocalPort += 2
            tries += 1
```

Handled non-iterative item like int in the args[0]. In args[0] the value can be sometimes an integer, so we cannot loop over it. In that case  `for row in args[0]:` will throw an error. Now that we have wrapped the code in the try block it should handle not-iterative args[0] elements
```
try:
    for row in args[0]:
        if row[1].replace(" ", "").lower() == "failmessage":
            custom_fail_message = row[2]
    # Todo: print the custom_fail_message
    CommonUtil.ExecLog(None, custom_fail_message, 3)
except:
    pass
```   
