### PR TITLE
Try to teardown browser directly from selenium_driver variable

### DIFF
--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -3928,6 +3928,14 @@ def Tear_Down_Selenium(step_data=[]):
                     errMsg = "Unable to tear down driver_id='%s'. may already been killed" % driver
                     CommonUtil.ExecLog(sModuleInfo, errMsg, 2)
                     CommonUtil.Exception_Handler(sys.exc_info(), None, errMsg)
+            
+            try:
+                selenium_driver.quit()
+            except:
+                errMsg = "Unable to tear down driver='%s'. may already been killed" % selenium_driver
+                CommonUtil.ExecLog(sModuleInfo, errMsg, 2)
+                CommonUtil.Exception_Handler(sys.exc_info(), None, errMsg)
+                
             Shared_Resources.Remove_From_Shared_Variables("selenium_driver")
             selenium_details = {}
             selenium_driver = None


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
A bug was reported that chrome process being running after testcase deployment in finished. Now the selenium_driver variable is cleared to make sure no chrome instance ( if it's missing in selenium_details for any reason)

Tested performed in Linux
- Deploy 
    - Individual deploy with passing testcase
    - Individual deploy with failing testcase
    - Deploy in set with passing testcases
    - Deploy in set with failing testcases
- Debug
    - Individual debug with passing testcase
    - Individual debug with failing testcase
    - Debug in set with passing testcases
    - Debug in set with failing testcases

Also tried with other combinations
- Failed/Blocked
- With/Without sepearte teardown step
