### PR TITLE
disable no sandbox

### DIFF
--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -676,7 +676,7 @@ def Open_Browser(dependency, window_size_X=None, window_size_Y=None, capability=
 
             # argument
             if not browser_options:
-                options.add_argument("--no-sandbox")
+                # options.add_argument("--no-sandbox")
                 # options.add_argument("--disable-extensions")
                 options.add_argument('--ignore-certificate-errors')
                 options.add_argument('--ignore-ssl-errors')
@@ -917,7 +917,7 @@ def Open_Browser(dependency, window_size_X=None, window_size_Y=None, capability=
 
             options.add_experimental_option("prefs", {"download.default_directory": download_dir})
             options.add_argument('--zeuz_pid_finder')
-            options.add_argument("--no-sandbox")
+            # options.add_argument("--no-sandbox")
             # options.add_argument("--disable-extensions")
             options.add_argument('--ignore-certificate-errors')
             options.add_argument('--ignore-ssl-errors')


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
PR_TYPE


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
Two left over processes was running when chrome is closed down. Removing the sand-box argument solved the issue. 

## Test Cases
- [TEST-0000](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-0000/)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
