### PR TITLE
[FIX] Use zeuz download folder in Firefox to download files

### DIFF
--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -843,6 +843,13 @@ def Open_Browser(dependency, window_size_X=None, window_size_Y=None, capability=
             apps = "application/pdf;text/plain;application/text;text/xml;application/xml;application/xlsx;application/csv;application/zip"
             profile.set_preference("browser.helperApps.neverAsk.saveToDisk", apps)
             profile.accept_untrusted_certs = True
+
+            options.set_preference("browser.download.folderList", 2)
+            options.set_preference("browser.download.manager.showWhenStarting", False)
+            options.set_preference("browser.download.dir", download_dir)
+            options.set_preference("browser.helperApps.neverAsk.saveToDisk", apps)
+            options.accept_untrusted_certs = True
+            
             if(remote_host):
                 capabilities = webdriver.DesiredCapabilities().FIREFOX
                 capabilities['acceptSslCerts'] = True


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
Selenium removed support for FirefoxProfile argument in driver initialization. The download folder settings needs to be passed using Options now. 
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

## Test Cases
- [TEST-04557000](https://automationserver.qa.successkpi.net/Home/ManageTestCases/Edit/TEST-4557/)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
