### PR TITLE
ios app can be launched using bundle id

### DIFF
--- a/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
@@ -869,17 +869,21 @@ def start_appium_driver(
                         # saving simulator path for future use
                         Shared_Resources.Set_Shared_Variables("ios_simulator_folder_path", str(app))
 
-                    app = os.path.join(app, ios)
-                    encoding = "utf-8"
-                    bundle_id = str(
-                        subprocess.check_output(
-                            ["osascript", "-e", 'id of app "%s"' % str(app)]
-                        ),
-                        encoding=encoding,
-                    ).strip()
+                    ios_part = ios.split('.')[0]
+                    if ios_part == 'com':
+                        desired_caps["bundleId"] = ios
+                    else:               
+                        app = os.path.join(app, ios)
+                        encoding = "utf-8"
+                        bundle_id = str(
+                            subprocess.check_output(
+                                ["osascript", "-e", 'id of app "%s"' % str(app)]
+                            ),
+                            encoding=encoding,
+                        ).strip()
 
-                    desired_caps["app"] = app  # Use set_value() for writing to element
-                    desired_caps["bundleId"] = bundle_id.replace("\\n", "")
+                        desired_caps["app"] = app  # Use set_value() for writing to element
+                        desired_caps["bundleId"] = bundle_id.replace("\\n", "")
 
                 desired_caps["platformName"] = "iOS"  # Read version #!!! Temporarily hard coded
                 desired_caps["platformVersion"] = platform_version


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

The code will check if we have provided the bundle id of the application we want to launch. If the bundle id is provided it will launch the app corresponding to that bundle id.

## Test Cases

<!-- If this PR fixes or closes an issue, reference it here. -->
