### PR TITLE
added check if variable name empty or not

### DIFF
--- a/Framework/Built_In_Automation/Desktop/CrossPlatform/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Desktop/CrossPlatform/BuiltInFunctions.py
@@ -1429,15 +1429,16 @@ def ocr_get_value_with_coordinates(data_set):
             )
         return "zeuz_failed"
     
-    if (topcord >  bottomcord or leftcord > rightcord):
+    # check if the variable name is provided or not
+    if var_name == "":
         CommonUtil.ExecLog(
-                sModuleInfo, "Please insert correct coordinates", 3
+                sModuleInfo, "Please provide a variable name to store the extracted value", 3
             )
         return "zeuz_failed"
     
-    if var_name is None:
+    if (topcord >  bottomcord or leftcord > rightcord):
         CommonUtil.ExecLog(
-                sModuleInfo, "Please provide a variable name to store the extracted value", 3
+                sModuleInfo, "Please insert correct coordinates", 3
             )
         return "zeuz_failed"
 
@@ -1535,6 +1536,13 @@ def ocr_get_value_with_image(data_set):
             )
         return "zeuz_failed"
     
+    # check if the variable name is provided or not
+    if var_name == "":
+        CommonUtil.ExecLog(
+                sModuleInfo, "Please provide a variable name to store the extracted value", 3
+            )
+        return "zeuz_failed"
+    
     get_bbox_dataset = (
         ("image", "element parameter", f"{image_name}"),
         ("get bounding box", "desktop action", "coords")
@@ -1609,6 +1617,13 @@ def ocr_get_value_with_text(data_set):
     except:
         CommonUtil.ExecLog(
                 sModuleInfo, "Could not parse the data", 3
+            )
+        return "zeuz_failed"
+    
+    # check if the variable name is provided or not
+    if var_name == "":
+        CommonUtil.ExecLog(
+                sModuleInfo, "Please provide a variable name to store the extracted value", 3
             )
         return "zeuz_failed"
     


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

Previously even if we didn't provide any variable name for the OCR actions that were extracting some texts and saving them into a vriable the action passed successfully which was a bug. Now I have added the check to see, if the variable name is empty then it will throw an error

```
if var_name == "":
        CommonUtil.ExecLog(
                sModuleInfo, "Please provide a variable name to store the extracted value", 3
            )
        return "zeuz_failed"
```

This check has been added to the following functions
- ocr_get_value_with_coordinates
- ocr_get_value_with_image
- ocr_get_value_with_text

## Test Cases
- [TEST-7704](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-7704/)

