### PR TITLE
Proxy implementation for capturing browser generated traffic

### DIFF
--- a/Framework/Built_In_Automation/Sequential_Actions/action_declarations/common.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/action_declarations/common.py
@@ -131,6 +131,8 @@ declarations = (
 
     {"name": "connect to google service client",            "function": "connect_to_google_service_account",     "screenshot": "none" },
     {"name": "upload to google storage bucket",             "function": "upload_to_google_storage_bucket",       "screenshot": "none" },
+
+    {"name": "proxy server",                                "function": "proxy_server",                         "screenshot": "none"}
     
 ) # yapf: disable
 

--- a/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
@@ -6760,6 +6760,7 @@ def proxy_server(data_set):
         CommonUtil.ExecLog(sModuleInfo, "Incorrect dataset", 3)
         return "zeuz_failed"
 
+
     if action == 'start':        
         CommonUtil.ExecLog(sModuleInfo, f"{action.capitalize()}ing proxy server on port {port}", 1)
 
@@ -6772,15 +6773,16 @@ def proxy_server(data_set):
         captured_network_file_path = proxy_log_dir / 'captured_network_data.csv'
         CommonUtil.ExecLog(sModuleInfo, f"Captured Network file: {output_file_path}", 1)
         # Open the output file in append mode
-        command = f'mitmdump -s {mitm_proxy_path} {captured_network_file_path} -p {port} >> {output_file_path} 2>&1 &'
-        os.system(command)
-
-        # Retrieve the PID of the process running on the specified port
-        pid_command = f"lsof -t -i:{port}"
-        pid = subprocess.check_output(pid_command, shell=True).decode().strip()
-
-        # Append the PID to the list and log
-        CommonUtil.mitm_proxy_pids.append(int(pid))
+        with open(output_file_path, 'a') as output_file:
+            # Start the subprocess
+            process = subprocess.Popen(
+            ['mitmdump', '-s', str(mitm_proxy_path), '-w', str(captured_network_file_path), '-p', str(port)],
+            stdout=output_file,  # Redirect stdout to the file
+            stderr=output_file   # Redirect stderr to the file
+        )
+            
+        pid = process.pid
+        CommonUtil.mitm_proxy_pids.append(pid)
         CommonUtil.ExecLog(sModuleInfo, f"Started process with PID: {pid}", 1)
 
         sr.Set_Shared_Variables(proxy_var, {"pid":pid,"captured_network_file_path":captured_network_file_path,"log_file":output_file_path})

--- a/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
@@ -6776,9 +6776,17 @@ def proxy_server(data_set):
         with open(r'{}'.format(output_file_path), 'a') as output_file:
             # Start the subprocess
             process = subprocess.Popen(
-                ['mitmdump', '-s', r'{}'.format(str(mitm_proxy_path)), '-w', r'{}'.format(str(captured_network_file_path)), '-p', str(port)],
+                [
+                    "mitmdump",
+                    "-s",
+                    f"{mitm_proxy_path}",
+                    "-p",
+                    str(port),
+                    "--set",
+                    f"output_file_path={captured_network_file_path}",
+                ],
                 stdout=output_file,  # Redirect stdout to the file
-                stderr=output_file   # Redirect stderr to the file
+                stderr=output_file,  # Redirect stderr to the file
             )
             
         pid = process.pid

--- a/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
@@ -6780,7 +6780,7 @@ def proxy_server(data_set):
         with open(output_file_path, 'a') as output_file:
             # Start the subprocess
             process = subprocess.Popen(
-                ['mitmdump', '-s', mitm_proxy_path, captured_network_file_path],
+                ['mitmdump', '-s', str(mitm_proxy_path), str(captured_network_file_path)],
                 stdout=output_file,  # Redirect stdout to the file
                 stderr=output_file   # Redirect stderr to the file
             )

--- a/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
@@ -6762,15 +6762,20 @@ def proxy_server(data_set):
 
     if action == 'start':        
         CommonUtil.ExecLog(sModuleInfo, f"{action.capitalize()}ing proxy server on port {port}", 1)
+        from pathlib import PurePosixPath
 
-        proxy_log_dir = Path(sr.Get_Shared_Variables("zeuz_download_folder")).parent / 'proxy_log'
+        proxy_log_dir = PurePosixPath(sr.Get_Shared_Variables("zeuz_download_folder")).parent / 'proxy_log'
         os.makedirs(proxy_log_dir, exist_ok=True)
-        mitm_proxy_path = Path(__file__).parent / "mitm_proxy.py"
+
+        # Paths for mitm_proxy and output files
+        mitm_proxy_path = PurePosixPath(__file__).parent / "mitm_proxy.py"
         output_file_path = proxy_log_dir / 'mitm.log'  # Output file to save the logs
+
+        # Logging the output paths
         CommonUtil.ExecLog(sModuleInfo, f"Proxy Log file: {output_file_path}", 1)
 
         captured_network_file_path = proxy_log_dir / 'captured_network_data.csv'
-        CommonUtil.ExecLog(sModuleInfo, f"Captured Network file: {output_file_path}", 1)
+        CommonUtil.ExecLog(sModuleInfo, f"Captured Network file: {captured_network_file_path}", 1)
         # Open the output file in append mode
         with open(output_file_path, 'a') as output_file:
             # Start the subprocess

--- a/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
@@ -6773,13 +6773,13 @@ def proxy_server(data_set):
         captured_network_file_path = proxy_log_dir / 'captured_network_data.csv'
         CommonUtil.ExecLog(sModuleInfo, f"Captured Network file: {output_file_path}", 1)
         # Open the output file in append mode
-        with open(output_file_path, 'a') as output_file:
+        with open(r'{}'.format(output_file_path), 'a') as output_file:
             # Start the subprocess
             process = subprocess.Popen(
-            ['mitmdump', '-s', str(mitm_proxy_path), '-w', str(captured_network_file_path), '-p', str(port)],
-            stdout=output_file,  # Redirect stdout to the file
-            stderr=output_file   # Redirect stderr to the file
-        )
+                ['mitmdump', '-s', r'{}'.format(str(mitm_proxy_path)), '-w', r'{}'.format(str(captured_network_file_path)), '-p', str(port)],
+                stdout=output_file,  # Redirect stdout to the file
+                stderr=output_file   # Redirect stderr to the file
+            )
             
         pid = process.pid
         CommonUtil.mitm_proxy_pids.append(pid)

--- a/Framework/Built_In_Automation/Sequential_Actions/mitm_proxy.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/mitm_proxy.py
@@ -1,0 +1,60 @@
+from mitmproxy import http
+import time
+import sys
+import csv
+import os
+
+# Initialize a list to track request details
+requests_data = []
+
+# Get the output file path from command-line arguments
+output_file_path = sys.argv[3] if len(sys.argv) > 3 else 'default_output.csv'
+print(f"OUTPUT: {output_file_path}")
+
+# Create a CSV file and write headers if the file does not exist
+if not os.path.exists(output_file_path):
+    with open(output_file_path, 'w', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(["url", "status_code", "duration in seconds", "content_length in bytes", "timestamp"])  # Write CSV header
+
+def request(flow: http.HTTPFlow) -> None:
+    # Capture request data when it's made
+    start_time = time.time()
+    requests_data.append({
+        'url': flow.request.url,
+        'start_time': start_time,
+        'status_code': None,
+        'end_time': None,
+        'duration': None,
+        'content_length': None
+    })
+
+def response(flow: http.HTTPFlow) -> None:
+    res = flow.response
+    end_time = time.time()
+
+    # Find the matching request based on the URL
+    for req in requests_data:
+        if req['url'] == flow.request.url:
+            req['status_code'] = res.status_code
+            req['end_time'] = end_time
+            req['duration'] = end_time - req['start_time']
+            req['content_length'] = len(res.content)
+            break
+
+    # Create a list to hold the captured details
+    captured_details = [
+        flow.request.url,
+        res.status_code,
+        req.get('duration', None),
+        len(res.content),
+        end_time
+    ]
+
+    # Append the captured details as a row in the CSV file
+    with open(output_file_path, 'a', newline='') as csvfile:
+        writer = csv.writer(csvfile)
+        writer.writerow(captured_details)  # Write CSV row
+
+    # Optionally print captured details for console output
+    print(f"Captured: {captured_details}")

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -189,6 +189,8 @@ global_var = {}
 global_sleep = {"selenium":{}, "appium":{}, "windows":{}, "desktop":{}}
 zeuz_disable_var_print = {}
 
+mitm_proxy_pids = []
+
 def clear_performance_metrics():
     """reset everything to initial value"""
     global browser_perf, action_perf, step_perf, test_case_perf, perf_test_perf, api_performance_data, load_testing, processed_performance_data

--- a/Framework/test.py
+++ b/Framework/test.py
@@ -1,0 +1,57 @@
+import os
+import subprocess
+from Utilities import CommonUtil
+from pathlib import Path
+
+OUTPUT_FILEPATH = "/Users/sakib/Documents/zeuz/Zeuz_Python_Node/AutomationLog/debug_sakib_dd446e56-a_AaRlG/session_1/TEST-10894/zeuz_download_folder/proxy_log/mitm.log"
+CAPTURED_CSV_FILEPATH = "/Users/sakib/Documents/zeuz/Zeuz_Python_Node/AutomationLog/debug_sakib_dd446e56-a_AaRlG/session_1/TEST-10894/zeuz_download_folder/proxy_log/captured_network_data.csv"
+MITM_PROXY_PATH = "/Users/sakib/Documents/zeuz/Zeuz_Python_Node/Framework/Built_In_Automation/Sequential_Actions/mitm_proxy.py"
+PORT = 8080 
+
+
+print(f"Starting proxy server on port {PORT}")
+
+print(f"MITM Proxy path: {MITM_PROXY_PATH}")
+print(f"Proxy Log file: {OUTPUT_FILEPATH}")
+
+print(f"Captured Network file: {CAPTURED_CSV_FILEPATH}")
+
+# Open the output file in append mode
+with open(OUTPUT_FILEPATH, 'a') as output_file:
+    # Start the subprocess
+    process = subprocess.Popen(
+        ['mitmdump', '-s', MITM_PROXY_PATH, '-w', str(CAPTURED_CSV_FILEPATH), '-p', str(PORT)],
+        stdout=output_file,  # Redirect stdout to the file
+        stderr=output_file   # Redirect stderr to the file
+    )
+    
+pid = process.pid
+
+# Assuming CommonUtil.mitm_proxy_pids is a list, make sure it's initialized properly
+if not hasattr(CommonUtil, 'mitm_proxy_pids'):
+    CommonUtil.mitm_proxy_pids = []
+
+CommonUtil.mitm_proxy_pids.append(pid)
+
+import time
+time.sleep(2)
+
+# Verify if the service is running on the specified port
+def verify_port_in_use(port):
+    if os.name == 'posix':  # macOS/Linux
+        result = subprocess.run(['lsof', '-i', f':{port}'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        return result.stdout
+    elif os.name == 'nt':  # Windows
+        result = subprocess.run(['netstat', '-aon'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        return result.stdout if f':{port}' in result.stdout else ''
+
+# Check if the port is in use
+port_status = verify_port_in_use(PORT)
+
+if port_status:
+    print(f"Service is running on port {PORT}:\n{port_status}")
+else:
+    print(f"Service is NOT running on port {PORT}. Check if the subprocess started correctly.")
+
+# Prevent the script from exiting immediately
+input("Press Enter to exit...\n")

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -56,7 +56,6 @@ jinja2
 pandas
 pyperclip
 thefuzz
-backports-datetime-fromisoformat; python_version < '3.11'
 genson
 google-cloud-storage
 mitmproxy

--- a/requirements-linux.txt
+++ b/requirements-linux.txt
@@ -59,3 +59,4 @@ thefuzz
 backports-datetime-fromisoformat; python_version < '3.11'
 genson
 google-cloud-storage
+mitmproxy

--- a/requirements-mac.txt
+++ b/requirements-mac.txt
@@ -59,7 +59,6 @@ configobj
 jinja2
 pandas
 pyperclip
-backports-datetime-fromisoformat; python_version < '3.11'
 thefuzz
 genson
 google-cloud-storage

--- a/requirements-mac.txt
+++ b/requirements-mac.txt
@@ -63,3 +63,4 @@ backports-datetime-fromisoformat; python_version < '3.11'
 thefuzz
 genson
 google-cloud-storage
+mitmproxy

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -73,3 +73,4 @@ backports-datetime-fromisoformat; python_version < '3.11'
 thefuzz
 genson
 google-cloud-storage
+mitmproxy

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -69,7 +69,6 @@ configobj
 jinja2
 pandas
 pyperclip
-backports-datetime-fromisoformat; python_version < '3.11'
 thefuzz
 genson
 google-cloud-storage

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,3 +54,4 @@ pyperclip
 backports-datetime-fromisoformat; python_version < '3.11'
 genson
 google-cloud-storage
+mitmproxy

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,6 @@ configobj
 boto3
 pandas
 pyperclip
-backports-datetime-fromisoformat; python_version < '3.11'
 genson
 google-cloud-storage
 mitmproxy


### PR DESCRIPTION
## How to install certificate
### Mac OS
Make sure the mitmproxy module is installed. Then run this command
```
bash
sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain ~/.mitmproxy/mitmproxy-ca-cert.pem
```

### Ubuntu - Chrome

Open Chrome Browser and Navigate to `chrome://settings/certificates`
Click on the `Authorities tab` and then the `Import` button
![image](https://github.com/user-attachments/assets/5aed3245-4267-49f0-a3d1-77006ae4159c)

Select `mitmproxy-ca-cert.crt` file in your `~/.mitmproxy` directory
![image](https://github.com/user-attachments/assets/ff1fedd7-ad6a-41d3-a950-7383ca95cdc5)

Check all the boxes and click OK
![image](https://github.com/user-attachments/assets/32cffcd8-3b42-472f-853a-79ab71701287)

Verify the certificate has been added
![image](https://github.com/user-attachments/assets/c66c02ce-8fd9-4570-99e9-7504abdcbeff)


### Windows
```
bash
certutil.exe -addstore root mitmproxy-ca-cert.cer
```
##### Alternative

User ZeuZ testcase to run the proxy and visit `mitm.it` website with go to link action in debug mode. Download the cer file for windows

1. Double-click the P12 file to start the import wizard.
![Screenshot from 2024-10-07 22-06-38](https://github.com/user-attachments/assets/a5ec735f-68f9-4d74-beff-f4b87245b8e2)

2. Select a certificate store location. This determines who will trust the certificate – only the current Windows user or everyone on the machine. Click Next.
![Screenshot from 2024-10-07 22-06-57](https://github.com/user-attachments/assets/e733f4b8-243b-4353-aaf4-a64940cb7467)

3. Click Next again.
4. Leave Password blank and click Next.
![Screenshot from 2024-10-07 22-07-05](https://github.com/user-attachments/assets/06e0be70-4f89-4185-a5bd-9b1e78cbc9f4)

5. Select Place all certificates in the following store, then click Browse, and select Trusted Root Certification Authorities.
![Screenshot from 2024-10-07 22-07-44](https://github.com/user-attachments/assets/501a7ddd-c2d8-4fd5-938b-9c2e2e6c9457)

6. Click OK and Next.
![Screenshot from 2024-10-07 22-07-59](https://github.com/user-attachments/assets/49b9a402-74f7-4e49-9515-49ef29195a2b)

7.Click Finish.
8.Click Yes to confirm the warning dialog.

## PR Type
Feature


## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [x] Required modules have been added to respective "requirements*.txt" files.
- [x] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and server status.




## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Added a new action should start a proxy server. By default the port is 8080 which user can change.
| Parameter | Optional Parameter | Value |
|-----------|---------------------|---------|
| port          | optional parameter | 8080       |
| action        | element parameter   | start      |
| proxy server  | common action       | myserver   |

And for stopping the server
| Parameter     | Optional Parameter | Value    |
|---------------|--------------------|----------|
| proxy server  | common action       | myserver |
| action        | element parameter   | stop     |

Use the arguments in the `go to link` action to make the request go through the proxy server
| Parameter               | Optional Parameter | Value                                |
|-------------------------|--------------------|--------------------------------------|
| wait time to appear element | optional parameter | 10                                   |
| add argument             | chrome option      | --proxy-server=http://localhost:8080 |
| add argument             | chrome option      | --ignore-certificate-errors          |
| go to link               | selenium action    | https://google.com/                  |

An output storing in the AutomationLog folder or the log file of the RunID will hold the information of the traffics. The exact filepath (during debug) can be found in the `captured_network_file_path` key of the server variable (the value of proxy server parameter in the action)

<img width="948" alt="image" src="https://github.com/user-attachments/assets/ca54d0f5-b33c-4c06-bd05-a48b84def939">

## Test Cases
- [TEST-10894](https://qa.automationsolutionz.com/Home/ManageTestCases/Edit/TEST-10894/)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

<hr>


