### PR TITLE
Improve App Launch Stability with Keypress Interval Support and Added "wait" Parameter Synonym

### DIFF
--- a/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
@@ -2086,6 +2086,17 @@ def _open_inspector(inspector, args):
 
 @logger
 def Run_Application(data_set):
+    """
+    size	                        |   optional parameter  |	** Example: 1920,1080 **
+    location                        |	optional parameter  |	** Example: 0,0 **
+    maximize                        |	optional parameter  |	** yes/no **
+    relaunch/launch another         |	optional parameter  |	** yes/no **
+    keypress interval               |   optional parameter  |	** It will by default wait 0.5 sec for the keypress interval. Example: 0.2 **
+    wait for launch                 |	optional parameter  |	** It will by default wait 10 sec for the app to launch. Example: 20 **
+    open app                        |	windows action      |	Example:
+                                                                >> Outlook
+                                                                >> ~/Desktop/server.exe
+    """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global current_pid_list
     current_pid_list = []
@@ -2093,6 +2104,7 @@ def Run_Application(data_set):
         args = {"shell": True, "stdin": None, "stdout": None, "stderr": None}
         launch_cond = ""
         Desktop_app = ""
+        keypress_interval = 0.5
         size, top_left, maximize = None, None, False
         wait = Shared_Resources.Get_Shared_Variables("element_wait")
         for left, mid, right in data_set:
@@ -2117,7 +2129,9 @@ def Run_Application(data_set):
                 launch_cond = "relaunch"
             elif "launchagain" in left and yes_cond:
                 launch_cond = "launchagain"
-            elif "wait" == left:
+            elif "keypressinterval" in left and r != None:
+                keypress_interval = float(r)
+            elif left == "wait" or left == "waitforlaunch":
                 wait = float(r)
 
         if not launch_cond and len(pygetwindow.getWindowsWithTitle(Desktop_app)) > 0:
@@ -2133,13 +2147,13 @@ def Run_Application(data_set):
                 cmd = f'''{Desktop_app[:2]} && cd "{os.path.dirname(Desktop_app)}" && start cmd.exe /K "{Desktop_app}\"'''
                 CommonUtil.ExecLog(sModuleInfo, "Running following cmd:\n" + cmd, 1)
                 subprocess.Popen(cmd, **args)
-                # Desktop_app = os.path.basename(Desktop_app)
+                # Desktop_app = os.path.basename(Desktop_app)Notepad
             else:
                 #last_start_time = time.time()
                 autoit.send("^{ESC}")
-                time.sleep(0.5)
+                time.sleep(keypress_interval)
                 autoit.send(Desktop_app)
-                time.sleep(0.5)
+                time.sleep(keypress_interval)
                 autoit.send("{ENTER}")
                 CommonUtil.ExecLog(sModuleInfo, "Successfully launched your app", 1)
                 time.sleep(2)

--- a/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Desktop/Windows/BuiltInFunctions.py
@@ -2147,7 +2147,7 @@ def Run_Application(data_set):
                 cmd = f'''{Desktop_app[:2]} && cd "{os.path.dirname(Desktop_app)}" && start cmd.exe /K "{Desktop_app}\"'''
                 CommonUtil.ExecLog(sModuleInfo, "Running following cmd:\n" + cmd, 1)
                 subprocess.Popen(cmd, **args)
-                # Desktop_app = os.path.basename(Desktop_app)Notepad
+                # Desktop_app = os.path.basename(Desktop_app)
             else:
                 #last_start_time = time.time()
                 autoit.send("^{ESC}")


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [x] Required modules have been added to respective "requirements*.txt" files.
- [x] Relevant Test Cases added to this description (below).
- [x] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
The introduction of the keypress interval parameter addresses a key challenge with the Open App functionality, where the application launch was inconsistent due to timing issues during the keypress sequence. This feature provides a customizable delay between critical actions in the automated sequence to ensure smoother and more reliable application launches.

Here’s how users benefit and how it resolves the issue:

Enhanced App Search Stability
When pressing ESC to open the system search bar, the delay introduced by keypress interval ensures sufficient time for the search bar to appear before pasting the application's name. This avoids scenarios where the application name is entered before the search bar is ready to accept input, leading to failed launches.

Reliable Command Execution
After the application name is pasted into the search bar, another interval ensures that the name is fully entered before the ENTER key is pressed to execute the command. This prevents issues where the command might be sent prematurely, resulting in either no action or the wrong application opening.

Customizability for Varied System Speeds
Since system performance and search response times can vary, the keypress interval is fully customizable. Users can set an appropriate delay based on their environment, ensuring that the sequence works seamlessly across different setups.

**Behavioral Changes:**

Keypress Interval Customization
- Added support for a new optional parameter: keypress interval.
- Default value: 0.5 seconds.
- Example usage: ("keypress interval", "optional parameter", "0.2").

Improved Wait Parameter Handling
- Introduced both 'wait' and 'wait for launch' as synonyms for defining application launch wait time.
- The new synonym ensures compatibility with scripts using older versions of the function.

**Previous Action:**

![image](https://github.com/user-attachments/assets/f5d848d8-eb60-4c95-977f-b63a7a7311d7)

**Updated Action:**

![image](https://github.com/user-attachments/assets/4ceabeff-dfeb-495f-9876-d423eb621936)

## Keypoints
<!-- Emphasize any breaking changes. -->
- A keypress interval row is added
- Default value of keypress interval: 0.5 seconds
- The "wait" can be used both as "wait" and "wait for launch"

## Test Cases
- [TEST-11309](https://qa.automationsolutionz.com/Home/ManageTestCases/Edit/TEST-11309/#parentHorizontalTab2)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes  -->
