### PR TITLE
Send variable value to report log is done with some more fixes

### DIFF
--- a/Framework/Built_In_Automation/Shared_Resources/BuiltInFunctionSharedResources.py
+++ b/Framework/Built_In_Automation/Shared_Resources/BuiltInFunctionSharedResources.py
@@ -583,6 +583,10 @@ def parse_variable(name):
             elif len(indices) == 1:
                 result = result[0]
 
+             # send variable value in report logs and terminal
+            if str(shared_variables['log_variable_value']).lower() in {"on", "yes", "true", "1"}:
+                CommonUtil.AddVariableToLog(sModuleInfo, copy_of_name, result)
+
             # Print to console.
             # CommonUtil.prettify(copy_of_name, result)
             return result
@@ -606,6 +610,9 @@ def parse_variable(name):
             if len(indices) == 1:
                 result = result[0]
 
+            if str(shared_variables['log_variable_value']).lower() in {"on", "yes", "true", "1"}:
+                CommonUtil.AddVariableToLog(sModuleInfo, copy_of_name, result)
+
             # CommonUtil.prettify(copy_of_name, result)
             return result
         else:
@@ -616,6 +623,9 @@ def parse_variable(name):
                 if each_var in name:
                     val_to_print = '*****'
                     break
+
+            if str(shared_variables['log_variable_value']).lower() in {"on", "yes", "true", "1"} and not "os.environ" in name:
+                CommonUtil.AddVariableToLog(sModuleInfo, copy_of_name, val_to_print)
 
             # Print to console.
             # if not "os.environ" in name:

--- a/Framework/Built_In_Automation/Shared_Resources/BuiltInFunctionSharedResources.py
+++ b/Framework/Built_In_Automation/Shared_Resources/BuiltInFunctionSharedResources.py
@@ -584,7 +584,7 @@ def parse_variable(name):
                 result = result[0]
 
              # send variable value in report logs and terminal
-            if str(shared_variables['log_variable_value']).lower() in {"on", "yes", "true", "1"}:
+            if str(shared_variables['zeuz_enable_variable_logging']).lower() in {"on", "yes", "true", "1"}:
                 CommonUtil.AddVariableToLog(sModuleInfo, copy_of_name, result)
 
             # Print to console.
@@ -610,7 +610,7 @@ def parse_variable(name):
             if len(indices) == 1:
                 result = result[0]
 
-            if str(shared_variables['log_variable_value']).lower() in {"on", "yes", "true", "1"}:
+            if str(shared_variables['zeuz_enable_variable_logging']).lower() in {"on", "yes", "true", "1"}:
                 CommonUtil.AddVariableToLog(sModuleInfo, copy_of_name, result)
 
             # CommonUtil.prettify(copy_of_name, result)
@@ -624,7 +624,7 @@ def parse_variable(name):
                     val_to_print = '*****'
                     break
 
-            if str(shared_variables['log_variable_value']).lower() in {"on", "yes", "true", "1"} and not "os.environ" in name:
+            if str(shared_variables['zeuz_enable_variable_logging']).lower() in {"on", "yes", "true", "1"} and not "os.environ" in name:
                 CommonUtil.AddVariableToLog(sModuleInfo, copy_of_name, val_to_print)
 
             # Print to console.

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1990,8 +1990,8 @@ def main(device_dict, all_run_id_info):
             if not shared.Test_Shared_Variables("zeuz_collect_browser_log"):
                 shared.Set_Shared_Variables("zeuz_collect_browser_log", "on")
 
-            if not shared.Test_Shared_Variables("log_variable_value"):
-                shared.Set_Shared_Variables("log_variable_value", "False")
+            if not shared.Test_Shared_Variables("zeuz_enable_variable_logging"):
+                shared.Set_Shared_Variables("zeuz_enable_variable_logging", "False")
 
             shared.Set_Shared_Variables("run_id", run_id)
             shared.Set_Shared_Variables("node_id", CommonUtil.MachineInfo().getLocalUser())

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1990,6 +1990,9 @@ def main(device_dict, all_run_id_info):
             if not shared.Test_Shared_Variables("zeuz_collect_browser_log"):
                 shared.Set_Shared_Variables("zeuz_collect_browser_log", "on")
 
+            if not shared.Test_Shared_Variables("log_variable_value"):
+                shared.Set_Shared_Variables("log_variable_value", "False")
+
             shared.Set_Shared_Variables("run_id", run_id)
             shared.Set_Shared_Variables("node_id", CommonUtil.MachineInfo().getLocalUser())
 

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -299,8 +299,11 @@ def prettify(key, val):
         val_output = str(val)
 
     if isinstance(prettify_limit, int):
-        if len(val_output) > prettify_limit:
-            val_output = f"{val_output[:prettify_limit]}\n...(truncated {len(val_output)-prettify_limit} chars)"
+        #process the string based on negetive and positive prettify_limit value
+        if prettify_limit >= 0 and len(val_output) > prettify_limit:
+            val_output = f'{val_output[:prettify_limit+1]}{val_output[-1]}\n...(truncated {len(val_output) - prettify_limit} chars)'
+        elif prettify_limit < 0:
+            val_output = f'{val_output[:prettify_limit-1]}{val_output[-1]}\n...(truncated {-prettify_limit} chars)'
     else:
         val_output = str(val)
 
@@ -538,6 +541,40 @@ def clear_logs_from_report(send_log_file_only_for_fail, rerun_on_fail, sTestCase
         # del step["actions"]
         if send_log_file_only_for_fail and not rerun_on_fail and sTestCaseStatus == "Passed" and "log" in step:
             del step["log"]
+
+
+def AddVariableToLog(
+        sModuleInfo, key, val
+):
+
+    # do not print variables which are marked hidden
+    if key in zeuz_disable_var_print.keys():
+        return
+
+    try:
+        if type(val) == str:
+            val = parse_value_into_object(val)
+        val_output = json.dumps(val, indent=2)
+    except:
+        val_output = str(val)
+
+    if isinstance(prettify_limit, int):
+        #process the string based on negetive and positive prettify_limit value
+        if prettify_limit >= 0 and len(val_output) > prettify_limit:
+            val_output = f'{val_output[:prettify_limit+1]}{val_output[-1]}'
+        elif prettify_limit < 0:
+            val_output = f'{val_output[:prettify_limit-1]}{val_output[-1]}'
+    else:
+        val_output = str(val)
+
+    ExecLog(
+                sModuleInfo, "Variable: %s" % key, 5,
+                variable={
+                    "key": key,
+                    "val": val_output
+                }
+    )
+    prettify(key, val)
 
 
 def ExecLog(

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -572,7 +572,8 @@ def AddVariableToLog(
                 variable={
                     "key": key,
                     "val": val_output
-                }
+                },
+                print_Execlog = False
     )
     prettify(key, val)
 

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -301,9 +301,10 @@ def prettify(key, val):
     if isinstance(prettify_limit, int):
         #process the string based on negetive and positive prettify_limit value
         if prettify_limit >= 0 and len(val_output) > prettify_limit:
-            val_output = f'{val_output[:prettify_limit+1]}{val_output[-1]}\n...(truncated {len(val_output) - prettify_limit} chars)'
+            val_output = f"{val_output[:prettify_limit]}\n...(truncated {len(val_output) - prettify_limit} chars)"
         elif prettify_limit < 0:
-            val_output = f'{val_output[:prettify_limit-1]}{val_output[-1]}\n...(truncated {-prettify_limit} chars)'
+            val_output = f"{val_output[:prettify_limit]}\n...(truncated {-prettify_limit} chars)"
+
     else:
         val_output = str(val)
 
@@ -561,9 +562,9 @@ def AddVariableToLog(
     if isinstance(prettify_limit, int):
         #process the string based on negetive and positive prettify_limit value
         if prettify_limit >= 0 and len(val_output) > prettify_limit:
-            val_output = f'{val_output[:prettify_limit+1]}{val_output[-1]}'
+            val_output = f'{val_output[:prettify_limit]}'
         elif prettify_limit < 0:
-            val_output = f'{val_output[:prettify_limit-1]}{val_output[-1]}'
+            val_output = f'{val_output[:prettify_limit]}'
     else:
         val_output = str(val)
 


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [x] Required modules have been added to respective "requirements*.txt" files.
- [x] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
A new function AddVariableToLog is Added which will
- send Variable name and value to Report Log after truncating the value to prettify limit length
- print variable name and value in terminal
- Uses ExecLog and prettify function

Added a Runtime Paramter called **zeuz_enable_variable_logging** with value
- default: False
- "on" / "yes" / "true" / "1" (Upper or Lower case)

**Runtime parameter zeuz_enable_variable_logging is unset:**
![image](https://github.com/user-attachments/assets/d5db868a-1426-428a-ac5a-ba424a9a85f7)

**Runtime parameter zeuz_enable_variable_logging is set to True:**
![image](https://github.com/user-attachments/assets/6277fe02-45ae-476b-9ff0-7522299cf5e8)

Some Fixes
- Truncate message with prettify_limit with negetive value issue fixed
<!-- Emphasize any breaking changes. -->

## Tests
- Default of **zeuz_enable_variable_logging** is false
- "zeuz_enable_variable_logging" can hold "on"/ "yes"/ "true"/ "1" in both Uppercase and Lowercase.
- Truncate message in prettify() is checked for both positive and negetive prettify_limit value.
- Truncating without considerign the quatation is checked for string, list type variables
- Truncating value in both terminal and Report log is checked

## Test Cases
- [TEST-11332](https://qa.automationsolutionz.com/Home/ManageTestCases/Edit/TEST-11332/#parentHorizontalTab2)
- [TEST-11327](https://qa.automationsolutionz.com/Home/ManageTestCases/Edit/TEST-11327/#parentHorizontalTab2)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->

## Keypoints
- Added Runtime Parameter **zeuz_enable_variable_logging**
- default value of zeuz_enable_variable_logging = False
- Added funtion  AddVariableToLog to Print variable name and value in terminal and report log
