### PR TITLE
Fix status parsing from sender response

### DIFF
--- a/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
@@ -5942,8 +5942,8 @@ def data_store_read(data_set):
             verify=False,
             **headers
         )
-        response_json = json.loads(res.text)
         if res.status_code == 200:
+            response_json = json.loads(res.text)
             return sr.Set_Shared_Variables(var_name, response_json, pretty=True)
         else:
             CommonUtil.ExecLog(sModuleInfo, "No data found, please check your dataset", 1)

--- a/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
@@ -5943,12 +5943,10 @@ def data_store_read(data_set):
             **headers
         )
         response_json = json.loads(res.text)
-        status_code = response_json['status']
-        if status_code==200:
-            # CommonUtil.ExecLog(sModuleInfo, f"Captured following output:\n{res.text}", 1)
-            return sr.Set_Shared_Variables(var_name, json.loads(res.text),pretty=True)
+        if res.status_code == 200:
+            return sr.Set_Shared_Variables(var_name, response_json, pretty=True)
         else:
-            CommonUtil.ExecLog(sModuleInfo, "No data found , please check your dataset", 1)
+            CommonUtil.ExecLog(sModuleInfo, "No data found, please check your dataset", 1)
         return "passed"
 
     except Exception:

--- a/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
@@ -5942,12 +5942,10 @@ def data_store_read(data_set):
             verify=False,
             **headers
         )
-        #
-
-        # print(res.text)
-        if res.status_code==200:
+        response_json = json.loads(res.text)
+        status_code = response_json['status']
+        if status_code==200:
             # CommonUtil.ExecLog(sModuleInfo, f"Captured following output:\n{res.text}", 1)
-
             return sr.Set_Shared_Variables(var_name, json.loads(res.text),pretty=True)
         else:
             CommonUtil.ExecLog(sModuleInfo, "No data found , please check your dataset", 1)


### PR DESCRIPTION
## PR Type
🐞 Bug Fix

Previously, the status value from the sender's JSON response was not being read correctly. This caused issues in identifying response codes like `404`.

📌 Notes
This fix ensures better error handling and accurate status-based decision-making.