### PR TITLE
Image copy action

### DIFF
--- a/Framework/Built_In_Automation/Sequential_Actions/action_declarations/selenium.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/action_declarations/selenium.py
@@ -2,7 +2,7 @@ declarations = (
     { "name": "click",                         "function": "Click_Element",                 "screenshot": "web" },
     { "name": "click and hold",                "function": "Click_and_Hold_Element",        "screenshot": "web" },
     { "name": "click and download",            "function": "Click_and_Download",            "screenshot": "web" },
-    { "name": "right click",                   "function": "Right_Click_Element",         "screenshot": "web" },
+    { "name": "right click",                   "function": "Right_Click_Element",           "screenshot": "web" },
     { "name": "double click",                  "function": "Double_Click_Element",          "screenshot": "web" },
     { "name": "hover",                         "function": "Hover_Over_Element",            "screenshot": "web" },
     { "name": "keystroke keys",                "function": "Keystroke_For_Element",         "screenshot": "web" },
@@ -58,6 +58,7 @@ declarations = (
     { "name": "change attribute value",        "function": "Change_Attribute_Value",        "screenshot": "web" },
     { "name": "capture network log",           "function": "capture_network_log",           "screenshot": "web" },
     { "name": "if element exists",             "function": "if_element_exists",             "screenshot": "web" },
+    { "name": "copy image into browser",       "function": "copy_image_into_browser",       "screenshot": "web" },
 ) # yapf: disable
 
 module_name = "selenium"

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -18,6 +18,7 @@ import sys, os, time, inspect, shutil, subprocess, json
 import socket
 import requests
 import psutil
+import base64, imghdr
 from pathlib import Path
 sys.path.append("..")
 from selenium import webdriver
@@ -3458,3 +3459,154 @@ def if_element_exists(data_set):
         )
         return CommonUtil.Exception_Handler(sys.exc_info(), None, errMsg)
 
+
+@logger
+def copy_image_into_browser(data_set):
+    """
+    This action will copy an image from path or a variable into browser, and later you can paste via ctrl+v or cmd+v.
+
+    Example 1:
+    Field	                    Sub Field	            Value
+    image file                  element parameter	    %| image.png |%
+    image type                  optional parameter      image/png
+    copy image into browser     selenium action 	    switch window or frame
+
+    Example 2:
+    Field	                    Sub Field	            Value
+    image variable              element parameter       image_var
+    copy image into browser     selenium action 	    switch window or frame
+    """
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global selenium_driver
+    
+    try:
+        image_data = None
+        image_path = ""
+        variable_name = ""
+        mime_type = "image/png"
+        
+        # Parse
+        for left, mid, right in step_data:
+            left = left.lower().strip()
+            if left == "image file" and mid == "element parameter":
+                image_path = CommonUtil.path_parser(right.strip())
+            elif left == "image variable" and mid == "element parameter":
+                variable_name = right.strip()
+            elif left == "image type" and mid == "element parameter":
+                mime_type = right.strip().lower()
+        
+        if image_path:
+            if not os.path.exists(image_path):
+                CommonUtil.ExecLog(sModuleInfo, f"Image file not found: {image_path}", 3)
+                return "zeuz_failed"
+            
+            # if file type is not provided
+            if mime_type == "image/png":
+                detected_type = imghdr.what(image_path)
+                if detected_type:
+                    mime_type = f"image/{detected_type}"
+            
+            with open(image_path, "rb") as image_file:
+                image_data = image_file.read()
+
+        elif variable_name:
+            image_data = Shared_Resources.Get_Shared_Variables(variable_name)
+            if not image_data:
+                CommonUtil.ExecLog(sModuleInfo, f"Image data not found in variable: {variable_name}", 3)
+                return "zeuz_failed"
+
+        else:
+            CommonUtil.ExecLog(sModuleInfo, "Must provide either 'image file' or 'image variable'", 3)
+            return "zeuz_failed"
+        
+        # Convert
+        image_b64 = base64.b64encode(image_data).decode('utf-8')
+        
+        async_script = """
+        const base64Data = arguments[0];
+        const mimeType = arguments[1];
+        const callback = arguments[arguments.length - 1];
+        
+        function b64toBlob(b64Data, contentType) {
+            contentType = contentType || 'image/png';
+            const byteCharacters = atob(b64Data);
+            const byteArrays = [];
+            
+            for (let offset = 0; offset < byteCharacters.length; offset += 512) {
+                const slice = byteCharacters.slice(offset, offset + 512);
+                const byteNumbers = new Array(slice.length);
+                
+                for (let i = 0; i < slice.length; i++) {
+                    byteNumbers[i] = slice.charCodeAt(i);
+                }
+                
+                const byteArray = new Uint8Array(byteNumbers);
+                byteArrays.push(byteArray);
+            }
+            
+            return new Blob(byteArrays, {type: contentType});
+        }
+        
+        const blob = b64toBlob(base64Data, mimeType);
+        const item = new ClipboardItem({ [mimeType]: blob });
+        
+        navigator.clipboard.write([item])
+            .then(() => callback(true))
+            .catch(async (err) => {
+                console.error('Standard clipboard failed:', err);
+                
+                // Fallback for browsers with limited clipboard support
+                try {
+                    const textArea = document.createElement('textarea');
+                    textArea.value = 'Fallback clipboard content';
+                    document.body.appendChild(textArea);
+                    textArea.select();
+                    
+                    if (!document.execCommand('copy')) {
+                        throw new Error('execCommand failed');
+                    }
+                    
+                    document.body.removeChild(textArea);
+                    callback(true);
+                } catch (fallbackErr) {
+                    console.error('Fallback clipboard failed:', fallbackErr);
+                    callback(false);
+                }
+            });
+        """
+        
+        # Execute async script
+        success = selenium_driver.execute_async_script(async_script, image_b64, mime_type)
+        if not success:
+            CommonUtil.ExecLog(sModuleInfo, "Failed to write image to clipboard", 3)
+            return "zeuz_failed"
+        
+        # Robust OS detection for paste shortcut
+        capabilities = selenium_driver.capabilities
+        platform_name = capabilities.get('platformName', '').lower()
+        browser_name = capabilities.get('browserName', '').lower()
+        
+        # Determine paste key with comprehensive detection
+        if 'mac' in platform_name or 'os x' in platform_name:
+            paste_key = Keys.COMMAND
+        elif platform.system().lower() in ('darwin', 'macos'):
+            paste_key = Keys.COMMAND
+        else:
+            paste_key = Keys.CONTROL
+        
+        # Special handling for Firefox on Linux
+        if browser_name == 'firefox' and ('linux' in platform_name or platform.system().lower() == 'linux'):
+            paste_key = Keys.CONTROL
+        
+        # Simulate paste action with error handling
+        try:
+            ActionChains(selenium_driver).key_down(paste_key).send_keys('v').key_up(paste_key).perform()
+        except Exception as e:
+            CommonUtil.ExecLog(sModuleInfo, f"Standard paste failed: {str(e)}. Trying JavaScript fallback...", 2)
+            selenium_driver.execute_script("document.execCommand('paste');")
+        
+        CommonUtil.ExecLog(sModuleInfo, f"Image ({mime_type}) pasted successfully", 1)
+        return "passed"
+        
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -3574,15 +3574,26 @@ def copy_image_into_browser(data_set):
             const blob = new Blob(byteArrays, {type: mimeType});
             const item = new ClipboardItem({ [mimeType]: blob });
             
+            window.focus();
             navigator.clipboard.write([item])
-                .then(() => callback(true))
-                .catch(err => callback(false));
+                .then(() => {
+                    console.log('Successfully copied image to clipboard.');
+                    callback(true);
+                })
+                .catch(err => {
+                    console.log('Failed to copy image to clipboard', err);
+                    callback(false);
+                });
             """
-            
+
+            selenium_driver.switch_to.window(selenium_driver.current_window_handle)
+            selenium_driver.execute_script("window.focus();")
+
             success = selenium_driver.execute_async_script(async_script, image_b64, mime_type)
             if success:
                 CommonUtil.ExecLog(sModuleInfo, f"Image copied to clipboard: {image_path}", 1)
                 return "passed"
+            CommonUtil.ExecLog(sModuleInfo, f"Document is not focused. Failed to copy image to clipboard: {image_path}", 3)
             return "zeuz_failed"
 
         except Exception as e:

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -1263,7 +1263,63 @@ def Keystroke_For_Element(data_set):
             }
             for key in convert:
                 keystroke_value = keystroke_value.replace(key, convert[key])
-            if "+" in keystroke_value:
+                
+            # Special handling for paste command (Ctrl+V / Command+V)
+            normalized_keystroke = keystroke_value.replace(" ", "").replace("_", "").lower()
+            if normalized_keystroke in ("ctrl+v", "control+v", "ctrlv", "controlv", "cmd+v", "cmdv", "command+v", "commandv"):
+                capabilities = selenium_driver.capabilities
+                platform_name = capabilities.get('platformName', '').lower()
+                browser_name = capabilities.get('browserName', '').lower()
+                
+                if 'mac' in platform_name or 'os x' in platform_name:
+                    paste_key = Keys.COMMAND
+                elif platform.system().lower() in ('darwin', 'macos'):
+                    paste_key = Keys.COMMAND
+                else:
+                    paste_key = Keys.CONTROL
+                
+                if browser_name == 'firefox' and ('linux' in platform_name or platform.system().lower() == 'linux'):
+                    paste_key = Keys.CONTROL
+
+                try:
+                    if get_element:
+                        selenium_driver.execute_script("arguments[0].focus();", Element)
+                        time.sleep(0.1)
+                        
+                        # Perform paste using ActionChains
+                        actions = ActionChains(selenium_driver)
+                        actions.key_down(paste_key, element=Element)
+                        actions.send_keys_to_element(Element, 'v')
+                        actions.key_up(paste_key, element=Element)
+                        actions.perform()
+                    else:
+                        actions = ActionChains(selenium_driver)
+                        actions.key_down(paste_key)
+                        actions.send_keys('v')
+                        actions.key_up(paste_key)
+                        actions.perform()
+                        
+                    CommonUtil.ExecLog(sModuleInfo, "Paste command executed successfully", 1)
+                    return "passed"
+                except Exception as e:
+                    # Fallback to JavaScript if ActionChains fails
+                    try:
+                        CommonUtil.ExecLog(sModuleInfo, f"Standard paste failed: {str(e)}. Trying JavaScript fallback...", 2)
+                        if get_element:
+                            selenium_driver.execute_script("arguments[0].focus();", Element)
+                            selenium_driver.execute_script("arguments[0].value = arguments[1];", Element, pyperclip.paste())
+                        else:
+                            selenium_driver.execute_script(f"document.activeElement.value += '{pyperclip.paste()}';")
+                        CommonUtil.ExecLog(sModuleInfo, "Paste executed via JavaScript fallback", 1)
+                        return "passed"
+                    except Exception as js_e:
+                        return CommonUtil.Exception_Handler(
+                            sys.exc_info(),
+                            None,
+                            f"Both methods failed for paste operation: {str(js_e)}"
+                        )
+
+            elif "+" in keystroke_value:
                 hotkey_list = keystroke_value.split("+")
                 for i in range(len(hotkey_list)):
                     if hotkey_list[i] in list(dict(Keys.__dict__).keys())[2:-2]:

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -3510,7 +3510,7 @@ def copy_image_into_browser(data_set):
         elif variable_name:
             image_path = Shared_Resources.Get_Shared_Variables(variable_name)
             if not image_path:
-                CommonUtil.ExecLog(sModuleInfo, f"Image path not found in variable: {variable_name}. Make sure you must be use '%| |%' syntax for any variable.", 3)
+                CommonUtil.ExecLog(sModuleInfo, f"Image path not found in variable: {variable_name}. Make sure you must be use '%| |%' syntax for any variable or attachment.", 3)
                 return "zeuz_failed"
         else:
             CommonUtil.ExecLog(sModuleInfo, "Must provide either 'image file' or 'image variable'", 3)
@@ -3562,23 +3562,7 @@ def copy_image_into_browser(data_set):
             .then(() => callback(true))
             .catch(async (err) => {
                 console.error('Standard clipboard failed:', err);
-                
-                try {
-                    const textArea = document.createElement('textarea');
-                    textArea.value = 'Fallback clipboard content';
-                    document.body.appendChild(textArea);
-                    textArea.select();
-                    
-                    if (!document.execCommand('copy')) {
-                        throw new Error('execCommand failed');
-                    }
-                    
-                    document.body.removeChild(textArea);
-                    callback(true);
-                } catch (fallbackErr) {
-                    console.error('Fallback clipboard failed:', fallbackErr);
-                    callback(false);
-                }
+                callback(false);
             });
         """
         

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -3464,16 +3464,16 @@ def if_element_exists(data_set):
 def copy_image_into_browser(data_set):
     """
     This action will copy an image from path or a variable into browser, and later you can paste via ctrl+v or cmd+v.
-    Supported formats: PNG, JPG, WebP
+    Supported formats: PNG, SVG
 
     Example 1:
     Field	                    Sub Field	            Value
-    image file                  element parameter	    image.png
+    image file                  input parameter 	    %| image.png |%
     copy image into browser     selenium action 	    copy image into browser
 
     Example 2:
     Field	                    Sub Field	            Value
-    image variable              element parameter       image_var
+    image variable              input parameter         %| image_var |%
     copy image into browser     selenium action 	    copy image into browser
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
@@ -3487,13 +3487,22 @@ def copy_image_into_browser(data_set):
         
         # Parse
         for left, mid, right in data_set:
-            left = left.lower().strip()
-            mid = mid.lower().strip()
-            if left == "image file" and mid == "element parameter":
-                image_path = CommonUtil.path_parser(right.strip())
-            elif left == "image variable" and mid == "element parameter":
-                variable_name = right.strip()
-        
+            left = left.lower().replace(" ", "")
+            mid = mid.lower().replace(" ", "")
+            right = right.strip()
+
+            if left == "imagefile":
+                if os.path.exists(right):
+                    image_path = right
+                else:
+                    image_path = CommonUtil.path_parser(right)
+
+            elif left == "imagevariable":
+                if os.path.exists(right):
+                    image_path = right
+                else:
+                    variable_name = right
+
         if image_path:
             if not os.path.exists(image_path):
                 CommonUtil.ExecLog(sModuleInfo, f"Image file not found: {image_path}", 3)
@@ -3501,16 +3510,19 @@ def copy_image_into_browser(data_set):
         elif variable_name:
             image_path = Shared_Resources.Get_Shared_Variables(variable_name)
             if not image_path:
-                CommonUtil.ExecLog(sModuleInfo, f"Image data not found in variable: {variable_name}", 3)
+                CommonUtil.ExecLog(sModuleInfo, f"Image path not found in variable: {variable_name}. Make sure you must be use '%| |%' syntax for any variable.", 3)
                 return "zeuz_failed"
         else:
             CommonUtil.ExecLog(sModuleInfo, "Must provide either 'image file' or 'image variable'", 3)
             return "zeuz_failed"
         
-        if mime_type == "image/png":
-            detected_type = imghdr.what(image_path)
-            if detected_type:
-                mime_type = f"image/{detected_type}"
+        if image_path.lower().endswith(".svg"):
+            mime_type = "image/svg+xml"
+        elif image_path.lower().endswith(".png"):
+            mime_type = "image/png"
+        else:
+            CommonUtil.ExecLog(sModuleInfo, "Unsupported file format. You can copy only PNG or SVG image.", 2)
+            return "zeuz_failed"
         
         with open(image_path, "rb") as image_file:
             image_data = image_file.read()
@@ -3571,34 +3583,37 @@ def copy_image_into_browser(data_set):
         """
         
         success = selenium_driver.execute_async_script(async_script, image_b64, mime_type)
-        if not success:
+        if success:
+            CommonUtil.ExecLog(sModuleInfo, f"The image ({mime_type}) successfully copied to clipboard.", 1)
+            return "passed"
+        else:
             CommonUtil.ExecLog(sModuleInfo, "Failed to write image to clipboard", 3)
             return "zeuz_failed"
         
         ################################## PASTE ##################################
-        capabilities = selenium_driver.capabilities
-        platform_name = capabilities.get('platformName', '').lower()
-        browser_name = capabilities.get('browserName', '').lower()
+        # capabilities = selenium_driver.capabilities
+        # platform_name = capabilities.get('platformName', '').lower()
+        # browser_name = capabilities.get('browserName', '').lower()
         
-        if 'mac' in platform_name or 'os x' in platform_name:
-            paste_key = Keys.COMMAND
-        elif platform.system().lower() in ('darwin', 'macos'):
-            paste_key = Keys.COMMAND
-        else:
-            paste_key = Keys.CONTROL
+        # if 'mac' in platform_name or 'os x' in platform_name:
+        #     paste_key = Keys.COMMAND
+        # elif platform.system().lower() in ('darwin', 'macos'):
+        #     paste_key = Keys.COMMAND
+        # else:
+        #     paste_key = Keys.CONTROL
         
-        # handling for Firefox on Linux
-        if browser_name == 'firefox' and ('linux' in platform_name or platform.system().lower() == 'linux'):
-            paste_key = Keys.CONTROL
+        # # handling for Firefox on Linux
+        # if browser_name == 'firefox' and ('linux' in platform_name or platform.system().lower() == 'linux'):
+        #     paste_key = Keys.CONTROL
         
-        try:
-            ActionChains(selenium_driver).key_down(paste_key).send_keys('v').key_up(paste_key).perform()
-        except Exception as e:
-            CommonUtil.ExecLog(sModuleInfo, f"Standard paste failed: {str(e)}. Trying JavaScript fallback...", 2)
-            selenium_driver.execute_script("document.execCommand('paste');")
+        # try:
+        #     ActionChains(selenium_driver).key_down(paste_key).send_keys('v').key_up(paste_key).perform()
+        # except Exception as e:
+        #     CommonUtil.ExecLog(sModuleInfo, f"Standard paste failed: {str(e)}. Trying JavaScript fallback...", 2)
+        #     selenium_driver.execute_script("document.execCommand('paste');")
         
-        CommonUtil.ExecLog(sModuleInfo, f"Image ({mime_type}) pasted successfully", 1)
-        return "passed"
+        # CommonUtil.ExecLog(sModuleInfo, f"Image ({mime_type}) pasted successfully", 1)
+        # return "passed"
         
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -556,6 +556,7 @@ def generate_options(browser: str, browser_options:BrowserOptions):
         browser in ("chrome", "microsoft edge chromium")
     ):
         set_extension_variables()
+        options.add_argument("--disable-features=DisableLoadExtensionCommandLineSwitch")
         options.add_argument(f"load-extension={aiplugin_path},{ai_recorder_path}")
         # This is for running extension on a http server to call a https request
         options.add_argument("--allow-running-insecure-content")

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -3530,14 +3530,34 @@ def copy_image_into_browser(data_set):
         # Convert
         image_b64 = base64.b64encode(image_data).decode('utf-8')
         
-        async_script = """
-        const base64Data = arguments[0];
-        const mimeType = arguments[1];
-        const callback = arguments[arguments.length - 1];
-        
-        function b64toBlob(b64Data, contentType) {
-            contentType = contentType || 'image/png';
-            const byteCharacters = atob(b64Data);
+        browser_name = selenium_driver.capabilities.get('browserName', '').lower()
+        if browser_name in ('chrome', 'microsoft edge', 'edge'):
+            try:
+                selenium_driver.execute_cdp_cmd('Browser.setClipboard', {
+                    'data': image_b64,
+                    'type': mime_type
+                })
+                CommonUtil.ExecLog(sModuleInfo, f"Image copied to clipboard via CDP: {image_path}", 1)
+                return "passed"
+            except Exception as e:
+                CommonUtil.ExecLog(sModuleInfo, f"CDP failed ({str(e)}). Trying fallback method", 2)
+
+        try:
+            # Grant clipboard permissions via CDP if possible
+            try:
+                from urllib.parse import urlparse
+                parsed_uri = urlparse(selenium_driver.current_url)
+                origin = f'{parsed_uri.scheme}://{parsed_uri.netloc}'
+                selenium_driver.execute_cdp_cmd('Browser.grantPermissions', {
+                    'origin': origin,
+                    'permissions': ['clipboardReadWrite', 'clipboardSanitizedWrite']
+                })
+            except:
+                pass
+
+            async_script = """
+            const [base64Data, mimeType, callback] = arguments;
+            const byteCharacters = atob(base64Data);
             const byteArrays = [];
             
             for (let offset = 0; offset < byteCharacters.length; offset += 512) {
@@ -3548,56 +3568,26 @@ def copy_image_into_browser(data_set):
                     byteNumbers[i] = slice.charCodeAt(i);
                 }
                 
-                const byteArray = new Uint8Array(byteNumbers);
-                byteArrays.push(byteArray);
+                byteArrays.push(new Uint8Array(byteNumbers));
             }
             
-            return new Blob(byteArrays, {type: contentType});
-        }
-        
-        const blob = b64toBlob(base64Data, mimeType);
-        const item = new ClipboardItem({ [mimeType]: blob });
-        
-        navigator.clipboard.write([item])
-            .then(() => callback(true))
-            .catch(async (err) => {
-                console.error('Standard clipboard failed:', err);
-                callback(false);
-            });
-        """
-        
-        success = selenium_driver.execute_async_script(async_script, image_b64, mime_type)
-        if success:
-            CommonUtil.ExecLog(sModuleInfo, f"The image ({mime_type}) successfully copied to clipboard.", 1)
-            return "passed"
-        else:
-            CommonUtil.ExecLog(sModuleInfo, "Failed to write image to clipboard", 3)
+            const blob = new Blob(byteArrays, {type: mimeType});
+            const item = new ClipboardItem({ [mimeType]: blob });
+            
+            navigator.clipboard.write([item])
+                .then(() => callback(true))
+                .catch(err => callback(false));
+            """
+            
+            success = selenium_driver.execute_async_script(async_script, image_b64, mime_type)
+            if success:
+                CommonUtil.ExecLog(sModuleInfo, f"Image copied to clipboard: {image_path}", 1)
+                return "passed"
             return "zeuz_failed"
-        
-        ################################## PASTE ##################################
-        # capabilities = selenium_driver.capabilities
-        # platform_name = capabilities.get('platformName', '').lower()
-        # browser_name = capabilities.get('browserName', '').lower()
-        
-        # if 'mac' in platform_name or 'os x' in platform_name:
-        #     paste_key = Keys.COMMAND
-        # elif platform.system().lower() in ('darwin', 'macos'):
-        #     paste_key = Keys.COMMAND
-        # else:
-        #     paste_key = Keys.CONTROL
-        
-        # # handling for Firefox on Linux
-        # if browser_name == 'firefox' and ('linux' in platform_name or platform.system().lower() == 'linux'):
-        #     paste_key = Keys.CONTROL
-        
-        # try:
-        #     ActionChains(selenium_driver).key_down(paste_key).send_keys('v').key_up(paste_key).perform()
-        # except Exception as e:
-        #     CommonUtil.ExecLog(sModuleInfo, f"Standard paste failed: {str(e)}. Trying JavaScript fallback...", 2)
-        #     selenium_driver.execute_script("document.execCommand('paste');")
-        
-        # CommonUtil.ExecLog(sModuleInfo, f"Image ({mime_type}) pasted successfully", 1)
-        # return "passed"
-        
+
+        except Exception as e:
+            CommonUtil.ExecLog(sModuleInfo, f"Fallback method failed: {str(e)}", 3)
+            return "zeuz_failed"
+            
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -3467,14 +3467,14 @@ def copy_image_into_browser(data_set):
 
     Example 1:
     Field	                    Sub Field	            Value
-    image file                  element parameter	    %| image.png |%
+    image file                  element parameter	    image.png
     image type                  optional parameter      image/png
-    copy image into browser     selenium action 	    switch window or frame
+    copy image into browser     selenium action 	    copy image into browser
 
     Example 2:
     Field	                    Sub Field	            Value
     image variable              element parameter       image_var
-    copy image into browser     selenium action 	    switch window or frame
+    copy image into browser     selenium action 	    copy image into browser
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global selenium_driver
@@ -3492,7 +3492,7 @@ def copy_image_into_browser(data_set):
                 image_path = CommonUtil.path_parser(right.strip())
             elif left == "image variable" and mid == "element parameter":
                 variable_name = right.strip()
-            elif left == "image type" and mid == "element parameter":
+            elif left == "image type" and mid == "optional parameter":
                 mime_type = right.strip().lower()
         
         if image_path:
@@ -3514,6 +3514,9 @@ def copy_image_into_browser(data_set):
             if not image_data:
                 CommonUtil.ExecLog(sModuleInfo, f"Image data not found in variable: {variable_name}", 3)
                 return "zeuz_failed"
+            
+            with open(variable_name, "rb") as image_file:
+                image_data = image_file.read()
 
         else:
             CommonUtil.ExecLog(sModuleInfo, "Must provide either 'image file' or 'image variable'", 3)

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -3464,11 +3464,11 @@ def if_element_exists(data_set):
 def copy_image_into_browser(data_set):
     """
     This action will copy an image from path or a variable into browser, and later you can paste via ctrl+v or cmd+v.
+    Supported formats: PNG, JPG, WebP
 
     Example 1:
     Field	                    Sub Field	            Value
     image file                  element parameter	    image.png
-    image type                  optional parameter      image/png
     copy image into browser     selenium action 	    copy image into browser
 
     Example 2:
@@ -3486,41 +3486,34 @@ def copy_image_into_browser(data_set):
         mime_type = "image/png"
         
         # Parse
-        for left, mid, right in step_data:
+        for left, mid, right in data_set:
             left = left.lower().strip()
+            mid = mid.lower().strip()
             if left == "image file" and mid == "element parameter":
                 image_path = CommonUtil.path_parser(right.strip())
             elif left == "image variable" and mid == "element parameter":
                 variable_name = right.strip()
-            elif left == "image type" and mid == "optional parameter":
-                mime_type = right.strip().lower()
         
         if image_path:
             if not os.path.exists(image_path):
                 CommonUtil.ExecLog(sModuleInfo, f"Image file not found: {image_path}", 3)
                 return "zeuz_failed"
-            
-            # if file type is not provided
-            if mime_type == "image/png":
-                detected_type = imghdr.what(image_path)
-                if detected_type:
-                    mime_type = f"image/{detected_type}"
-            
-            with open(image_path, "rb") as image_file:
-                image_data = image_file.read()
-
         elif variable_name:
-            image_data = Shared_Resources.Get_Shared_Variables(variable_name)
-            if not image_data:
+            image_path = Shared_Resources.Get_Shared_Variables(variable_name)
+            if not image_path:
                 CommonUtil.ExecLog(sModuleInfo, f"Image data not found in variable: {variable_name}", 3)
                 return "zeuz_failed"
-            
-            with open(variable_name, "rb") as image_file:
-                image_data = image_file.read()
-
         else:
             CommonUtil.ExecLog(sModuleInfo, "Must provide either 'image file' or 'image variable'", 3)
             return "zeuz_failed"
+        
+        if mime_type == "image/png":
+            detected_type = imghdr.what(image_path)
+            if detected_type:
+                mime_type = f"image/{detected_type}"
+        
+        with open(image_path, "rb") as image_file:
+            image_data = image_file.read()
         
         # Convert
         image_b64 = base64.b64encode(image_data).decode('utf-8')
@@ -3558,7 +3551,6 @@ def copy_image_into_browser(data_set):
             .catch(async (err) => {
                 console.error('Standard clipboard failed:', err);
                 
-                // Fallback for browsers with limited clipboard support
                 try {
                     const textArea = document.createElement('textarea');
                     textArea.value = 'Fallback clipboard content';
@@ -3578,18 +3570,16 @@ def copy_image_into_browser(data_set):
             });
         """
         
-        # Execute async script
         success = selenium_driver.execute_async_script(async_script, image_b64, mime_type)
         if not success:
             CommonUtil.ExecLog(sModuleInfo, "Failed to write image to clipboard", 3)
             return "zeuz_failed"
         
-        # Robust OS detection for paste shortcut
+        ################################## PASTE ##################################
         capabilities = selenium_driver.capabilities
         platform_name = capabilities.get('platformName', '').lower()
         browser_name = capabilities.get('browserName', '').lower()
         
-        # Determine paste key with comprehensive detection
         if 'mac' in platform_name or 'os x' in platform_name:
             paste_key = Keys.COMMAND
         elif platform.system().lower() in ('darwin', 'macos'):
@@ -3597,11 +3587,10 @@ def copy_image_into_browser(data_set):
         else:
             paste_key = Keys.CONTROL
         
-        # Special handling for Firefox on Linux
+        # handling for Firefox on Linux
         if browser_name == 'firefox' and ('linux' in platform_name or platform.system().lower() == 'linux'):
             paste_key = Keys.CONTROL
         
-        # Simulate paste action with error handling
         try:
             ActionChains(selenium_driver).key_down(paste_key).send_keys('v').key_up(paste_key).perform()
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "pytz>=2025.1",
     "pywin32>=308 ; sys_platform == 'win32'",
     "pyyaml>=6.0.2",
+    "playwright>=1.52.0",
     "rauth>=0.7.3",
     "regex>=2024.11.6",
     "requests>=2.32.3",


### PR DESCRIPTION
## PR Type
Feature

## Test Case Link
[https://qa.zeuz.ai/Home/ManageTestCases/Edit/TEST-11696/#parentHorizontalTab2](https://qa.zeuz.ai/Home/ManageTestCases/Edit/TEST-11696/#parentHorizontalTab2)

## Overview
A new action added to the ZeuZ Node. 
This action will copy an image from path or a variable into browser, and later you can paste via ctrl+v or cmd+v.
Supported formats: PNG, SVG

Example 1:
Field	                    Sub Field	            Value
image file                  input parameter 	    %| image.png |%
copy image into browser     selenium action 	    copy image into browser

Example 2:
Field	                    Sub Field	            Value
image variable              input parameter         %| image_var |%
copy image into browser     selenium action 	    copy image into browser