### PR TITLE
fixed warning related to send_dom_variables

### DIFF
--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1177,7 +1177,15 @@ def send_dom_variables():
                     })
             except (json.decoder.JSONDecodeError, TypeError):
                 try:
-                    dir_ = { k:str(type(v)) for k,v in [(i, getattr(var_value, i)) for i in dir(var_value) if not i.startswith('__')]}
+                    dir_ = {}
+                    for attr_name in dir(var_value):
+                        if attr_name.startswith('__'):
+                            continue
+                        try:
+                            attr_value = getattr(var_value, attr_name)
+                            dir_[attr_name] = str(type(attr_value))
+                        except Exception:  # ignore getattr errors
+                            pass
                     variables.append({
                         "type": f"non_json: {str(var_value)}",
                         "variable_name": var_name,


### PR DESCRIPTION
## PR Type
Bug Fix


## PR Checklist
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
In node, for send_dom_variables function, the selenium's `getattr` function was giving error, which can be ignored, so now it's ignored.
