### PR TITLE
fixed a bug on cft open browser, removed maximize_window from open browser in Headless Chrome

### DIFF
--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -619,11 +619,11 @@ def Open_Browser(browser, browser_options: BrowserOptions):
                 options=options,
             )
 
-            service = Service()
-            selenium_driver = webdriver.Chrome(
-                service=service,
-                options=options,
-            )
+            # service = Service()
+            # selenium_driver = webdriver.Chrome(
+            #     service=service,
+            #     options=options,
+            # )
 
         elif browser in ("microsoft edge chromium", "edgechromiumheadless"):
             from selenium.webdriver.edge.service import Service
@@ -946,10 +946,12 @@ def Go_To_Link(dataset: Dataset) -> ReturnType:
                 window_size_X = ConfigModule.get_config_value("RunDefinition", "window_size_x")
                 window_size_Y = ConfigModule.get_config_value("RunDefinition", "window_size_y")
                 
+            # removed maximize_window function because it's give error in headless browser
             if not window_size_X and not window_size_Y:
-                selenium_driver.maximize_window()
-            else:
-                selenium_driver.set_window_size(window_size_X, window_size_Y)
+                import pyautogui
+                window_size_X, window_size_Y = pyautogui.size()
+            
+            selenium_driver.set_window_size(window_size_X, window_size_Y)
 
             selenium_details[driver_id] = {"driver": Shared_Resources.Get_Shared_Variables("selenium_driver")}
 

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -946,12 +946,14 @@ def Go_To_Link(dataset: Dataset) -> ReturnType:
                 window_size_X = ConfigModule.get_config_value("RunDefinition", "window_size_x")
                 window_size_Y = ConfigModule.get_config_value("RunDefinition", "window_size_y")
                 
-            # removed maximize_window function because it's give error in headless browser
             if not window_size_X and not window_size_Y:
-                import pyautogui
-                window_size_X, window_size_Y = pyautogui.size()
-            
-            selenium_driver.set_window_size(window_size_X, window_size_Y)
+                if dependency["Browser"] == "ChromeHeadless":
+                    window_size_X, window_size_Y = 1920, 1080
+                    selenium_driver.set_window_size(window_size_X, window_size_Y)
+                else:
+                    selenium_driver.maximize_window()
+            else:
+                selenium_driver.set_window_size(window_size_X, window_size_Y)
 
             selenium_details[driver_id] = {"driver": Shared_Resources.Get_Shared_Variables("selenium_driver")}
 


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
1. There was a critical bug on `Go To Link`. Mainly the `service` was created 2 times, if the condition do not met then it's create `selenium driver` without service. so it's fixed.
2. `selenium_driver.maximize_window()` is not works for VM's headless browser. so now it's replaced with pyautoGUI, and we are picking the primary window size and setting it. 

