### PR TITLE
No need to log zeuz_tc_logs not found

### DIFF
--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -709,7 +709,7 @@ def ExecLog(
             if iLogLevel == 3:
                 try:
                     from Framework.Built_In_Automation.Shared_Resources import BuiltInFunctionSharedResources as shared
-                    zeuz_tc_logs = shared.Get_Shared_Variables("zeuz_tc_logs")
+                    zeuz_tc_logs = shared.Get_Shared_Variables("zeuz_tc_logs", False)
                     if zeuz_tc_logs and isinstance(zeuz_tc_logs, dict):
                         now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                         error_entry = {


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
`zeuz_tc_logs` is a variable which stores error logs of a test case. This variable is only available in test cases, not anywhere else. So, many cases arise when this variable is not available. This is completely okay. This situation is handled properly. But log = False was not passing. This sometimes causes confusion. So, set log = False for accessing this variable for that particular line. Nothing is affected. No tests is needed. Just single word change.

## Test Cases
No tests

## Bugs
https://dev.zeuz.ai/Home/EditBug/BUG-76/
