### PR TITLE
Fixed bug: ctrl+v wasn't known by the input box

### DIFF
--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -1798,16 +1798,26 @@ def Keystroke_For_Element(data_set):
                                 "arguments[0].focus();", Element
                             )
                             selenium_driver.execute_script(
-                                "arguments[0].value = arguments[1];",
+                                """
+                                arguments[0].value = arguments[1];
+                                arguments[0].dispatchEvent(new Event('input', { bubbles: true }));
+                                arguments[0].dispatchEvent(new Event('change', { bubbles: true }));
+                                """,
                                 Element,
                                 pyperclip.paste(),
                             )
                         else:
                             selenium_driver.execute_script(
-                                f"document.activeElement.value += '{pyperclip.paste()}';"
+                                """
+                                var text = arguments[0];
+                                document.activeElement.value += text;
+                                document.activeElement.dispatchEvent(new Event('input', { bubbles: true }));
+                                document.activeElement.dispatchEvent(new Event('change', { bubbles: true }));
+                                """,
+                                pyperclip.paste(),
                             )
                         CommonUtil.ExecLog(
-                            sModuleInfo, "Paste successfully executed via JavaScript", 1
+                            sModuleInfo, "Paste successfully executed via JavaScript with events", 1
                         )
                         return "passed"
                     except Exception as js_e:


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
BUG FIX


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
when someone paste anything using ctrl+v then it doesn't know that something is pasted. so this is now fixed with js event.

## Test Cases
- [TEST-11622](https://qa.zeuz.ai/Home/ManageTestCases/Edit/TEST-11622/#parentHorizontalTab2)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
