### PR TITLE
Enable Windows notification for both debug and deployment test case runs

### DIFF
--- a/node_cli.py
+++ b/node_cli.py
@@ -529,8 +529,7 @@ def RunProcess(node_id, run_once=False, log_dir=None):
                 return False
 
             print("[deploy] Run complete.")
-            if CommonUtil.debug_status:
-                notify_complete("Run completed")
+            notify_complete("Run completed")
 
             if run_once:
                 return True
@@ -542,8 +541,7 @@ def RunProcess(node_id, run_once=False, log_dir=None):
                 return
 
             print("[deploy] Run cancelled.")
-            if CommonUtil.debug_status:
-                notify_complete("Run cancelled")
+            notify_complete("Run cancelled")
             CommonUtil.run_cancelled = True
 
         deploy_handler = long_poll_handler.DeployHandler(


### PR DESCRIPTION
Removes the condition check which used to display Windows notifications for only test case debug runs; now notifications are displayed for both debug and deployment runs.