### PR TITLE
CFT download function argument bug

### DIFF
--- a/Framework/Built_In_Automation/Web/Selenium/utils.py
+++ b/Framework/Built_In_Automation/Web/Selenium/utils.py
@@ -17,10 +17,6 @@ import datetime
 from datetime import timedelta
 import struct
 import urllib.request
-
-#for progress bar
-#from alive_progress import alive_bar
-
 from rich.progress import Progress
 
 
@@ -62,8 +58,8 @@ class ChromeForTesting:
             },
             "installed_versions": {},  # ex: ("132.0.6763.0" : "2025-07-02")
             "settings": {
-                "days_before_fetch": 7,     # set default fetch latest after 7 days
-                "days_before_cleanup": 90   # set default cleanup old versions after 90 days
+                "days_before_fetch": 15,     # set default fetch latest after 15 days
+                "days_before_cleanup": 50   # set default cleanup old versions after 50 days
             }
         }
         with open(self.CHROME_INFO_FILE, 'w') as f:
@@ -80,8 +76,8 @@ class ChromeForTesting:
             },
             "installed_versions": {},
             "settings": {
-                "days_before_fetch": 7,
-                "days_before_cleanup": 90
+                "days_before_fetch": 15,
+                "days_before_cleanup": 50
             }
         }
 
@@ -122,7 +118,7 @@ class ChromeForTesting:
             print(f"Using days_before_fetch from env: {days_before_fetch}")
         else:
             # otherwise use info.json or default
-            days_before_fetch = settings.get("days_before_fetch", 7)
+            days_before_fetch = settings.get("days_before_fetch", 15)
 
         #modification here to use settings for days_before_fetch
         if last_check_str and not force_check:
@@ -226,7 +222,7 @@ class ChromeForTesting:
         else:
             return driver_dir / driver_dir_name / "chromedriver"
 
-    def download_file(self, url):
+    def download_file(self, url, target_path, title):
         """Download file from URL"""
         response = requests.get(url, stream=True, verify=False)
         response.raise_for_status()
@@ -296,7 +292,7 @@ class ChromeForTesting:
             print(f"Using days_before_cleanup from env: {days_before_cleanup}")
         else:
             # otherwise use info.json or default
-            days_before_cleanup = settings.get("days_before_cleanup", 90)
+            days_before_cleanup = settings.get("days_before_cleanup", 50)
         
         #modification here to use settings for days_before_cleanup
         cutoff_date = today - timedelta(days=days_before_cleanup)
@@ -369,9 +365,13 @@ class ChromeForTesting:
         if not channel:
             channel = "Stable"
 
-        if version and version < "115.0.5763.0":
-            print("Chrome for testing version must be at least: '115.0.5763.0'")
-            return None, None
+        if version:
+            if version < "115.0.5763.0":
+                print("Chrome for testing version must be at least: '115.0.5763.0'")
+                return None, None
+            if version.strip().lower() == "none":
+                print("Forcefully trying to use regular chrome instead of chrome for testing.")
+                return None, None
         
         # Use latest version if not specified
         if not version:

--- a/node_cli.py
+++ b/node_cli.py
@@ -830,7 +830,7 @@ def command_line_args() -> Path | None:
         "--chrome-fetch",
         type=int,
         action="store",
-        help="Days before fetching new Chrome version (default: 7)",
+        help="Days before fetching new Chrome version (default: 15)",
         metavar="",
     )
     parser_object.add_argument(
@@ -838,7 +838,7 @@ def command_line_args() -> Path | None:
         "--chrome-cleanup",
         type=int,
         action="store",
-        help="Days before cleaning up old Chrome versions (default: 90)",
+        help="Days before cleaning up old Chrome versions (default: 50)",
         metavar="",
     )
 


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
BUG FIX


## Overview
- There was a bug on function `download_file` this file wasn't take title and target_path but it's using, so this problem is now fixed. 
- New cft version check is now extends by 15 days
- Old unused version is now can auto remove after 50 days
- User can pass 'chrome:version = 'none' in that case the regular chrome will be used instead of cft
