### PR TITLE
Zeuz secrets feature

### DIFF
--- a/Framework/Built_In_Automation/Shared_Resources/BuiltInFunctionSharedResources.py
+++ b/Framework/Built_In_Automation/Shared_Resources/BuiltInFunctionSharedResources.py
@@ -616,13 +616,26 @@ def parse_variable(name):
             # CommonUtil.prettify(copy_of_name, result)
             return result
         else:
-            val = eval(name, shared_variables)
+            from .secrets import secret
+            
+            eval_context = dict(shared_variables)
+            eval_context['secret'] = secret
+            
+            val = eval(name, eval_context)
             val_to_print = copy.deepcopy(val)
 
             for each_var in CommonUtil.zeuz_disable_var_print.keys():
                 if each_var in name:
                     val_to_print = '*****'
                     break
+            
+            if 'secret[' in name:
+                secret_key_match = re.search(r"secret\[['\"](.*?)['\"]\]", name)
+                if secret_key_match:
+                    secret_key = secret_key_match.group(1)
+                    if secret_key not in CommonUtil.zeuz_disable_var_print:
+                        CommonUtil.zeuz_disable_var_print[secret_key] = val
+                    val_to_print = '*****'
 
             if str(shared_variables['zeuz_enable_variable_logging']).lower() in {"on", "yes", "true", "1"} and not "os.environ" in name:
                 CommonUtil.AddVariableToLog(sModuleInfo, copy_of_name, val_to_print)

--- a/Framework/Built_In_Automation/Shared_Resources/secrets.py
+++ b/Framework/Built_In_Automation/Shared_Resources/secrets.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+"""
+ZeuZ Secrets Management Module
+
+This module provides secure access to encrypted secrets stored on the ZeuZ server.
+Secrets are automatically decrypted and can be accessed like a dictionary.
+
+Example:
+    from Framework.Built_In_Automation.Shared_Resources.secrets import secret
+    
+    # Access a secret
+    api_key = secret['my_api_key']
+    db_password = secret['database_password']
+"""
+
+import json
+import base64
+import inspect
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.padding import PKCS7
+
+from Framework.Utilities import CommonUtil, RequestFormatter
+from Framework.Built_In_Automation.Shared_Resources import BuiltInFunctionSharedResources as sr
+
+
+MODULE_NAME = inspect.getmodulename(__file__)
+
+
+class Secret:
+    """
+    A class to securely fetch and decrypt secrets from the ZeuZ server.
+    
+    Secrets are accessed like a dictionary: secret['key_name']
+    The class automatically:
+    - Fetches the encrypted secret from the server
+    - Decrypts it using the private key
+    - Caches the result for performance # Disabled for now
+    """
+    
+    def __init__(self):
+        self._cache: Dict[str, str] = {}
+        self._private_key_path = Path.home() / "zeuz_node_downloads" / "private_key.pem"
+        
+    def __getitem__(self, key_name: str) -> str:
+        """
+        Retrieve a secret by key name.
+        
+        Args:
+            key_name: The name of the secret to retrieve
+            
+        Returns:
+            The decrypted secret value
+            
+        Raises:
+            KeyError: If the secret cannot be found or accessed
+            Exception: If decryption fails
+        """
+        sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+        
+        if key_name in self._cache:
+            CommonUtil.ExecLog(sModuleInfo, f"Retrieved secret '{key_name}' from cache", 0)
+            return self._cache[key_name]
+        
+        try:
+            test_id = None
+            step_id = None
+            if sr.Test_Shared_Variables("zeuz_current_tc"):
+                current_tc = sr.Get_Shared_Variables("zeuz_current_tc")
+                if isinstance(current_tc, dict) and "testcase_no" in current_tc:
+                    test_id = current_tc["testcase_no"]
+            if sr.Test_Shared_Variables("zeuz_current_step"):
+                current_step = sr.Get_Shared_Variables("zeuz_current_step")
+                if isinstance(current_step, dict) and "step_id" in current_step:
+                    step_id = current_step["step_id"]
+            
+            params = {}
+            if test_id:
+                params["test_id"] = test_id
+            if step_id:
+                params["step_id"] = step_id
+
+            CommonUtil.ExecLog(sModuleInfo, f"Fetching secret '{key_name}' from server", 0)
+            
+            response = RequestFormatter.request(
+                method="GET",
+                url=RequestFormatter.form_uri(f"/d/api/v1/zeuz-secrets/{key_name}"),
+                params=params,
+                verify=False
+            )
+            
+            if response.status_code == 403:
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    f"Access denied to secret '{key_name}'. Check permissions.",
+                    3
+                )
+                raise KeyError(f"Access denied to secret '{key_name}'")
+            
+            if response.status_code != 200:
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    f"Failed to fetch secret '{key_name}': {response.status_code}",
+                    3
+                )
+                raise KeyError(f"Secret '{key_name}' not found or inaccessible")
+            
+            data = response.json()
+            encrypted_value = data.get("value")
+            
+            if not encrypted_value:
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    f"Secret '{key_name}' has no value",
+                    3
+                )
+                raise KeyError(f"Secret '{key_name}' has no value")
+            
+            decrypted_value = self._decrypt_data(encrypted_value)
+
+            
+            # Cache the decrypted value
+            # self._cache[key_name] = decrypted_value
+            
+            if key_name not in CommonUtil.zeuz_disable_var_print:
+                CommonUtil.zeuz_disable_var_print[key_name] = decrypted_value
+            
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"Successfully retrieved and decrypted secret '{key_name}'",
+                1
+            )
+            
+            return decrypted_value
+            
+        except KeyError:
+            raise
+        except Exception as e:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"Error retrieving secret '{key_name}': {str(e)}",
+                3
+            )
+            raise KeyError(f"Failed to retrieve secret '{key_name}': {str(e)}")
+
+    
+    def _load_private_key(self):
+        sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+        
+        try:
+            if not self._private_key_path.exists():
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    f"Private key not found at {self._private_key_path}",
+                    3
+                )
+                raise FileNotFoundError(f"Private key not found at {self._private_key_path}")
+            
+            with open(self._private_key_path, 'rb') as f:
+                return serialization.load_pem_private_key(f.read(), password=None)
+        except Exception as e:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"Failed to load private key: {str(e)}",
+                3
+            )
+            raise
+    
+    def _decrypt_data(self, encrypted_data: str) -> str:
+        """
+        Decrypt data that was encrypted using hybrid encryption (RSA + AES).
+        
+        Args:
+            encrypted_data: Base64 encoded JSON string containing encrypted key, IV, and data
+            
+        Returns:
+            Decrypted plaintext string
+        """
+        private_key = self._load_private_key()
+        
+        decoded_data = base64.b64decode(encrypted_data)
+        data = json.loads(decoded_data.decode('utf-8'))
+        
+        encrypted_aes_key = base64.b64decode(data['encryptedKey'])
+        aes_key = private_key.decrypt(
+            encrypted_aes_key,
+            padding.OAEP(
+                mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                algorithm=hashes.SHA256(),
+                label=None
+            )
+        )
+        
+        iv = base64.b64decode(data['iv'])
+        encrypted_content = base64.b64decode(data['encryptedData'])
+        
+        cipher = Cipher(algorithms.AES(aes_key), modes.CBC(iv))
+        decryptor = cipher.decryptor()
+        decrypted_padded = decryptor.update(encrypted_content) + decryptor.finalize()
+        
+        unpadder = PKCS7(128).unpadder()
+        decrypted = unpadder.update(decrypted_padded) + unpadder.finalize()
+        
+        return decrypted.decode('utf-8')
+    
+    def clear_cache(self, key_name: Optional[str] = None):
+        """
+        Clear the cache for a specific secret or all secrets.
+        
+        Args:
+            key_name: Optional specific secret to clear. If None, clears all.
+        """
+        if key_name:
+            self._cache.pop(key_name, None)
+        else:
+            self._cache.clear()
+
+
+secret = Secret()

--- a/Framework/Built_In_Automation/Shared_Resources/secrets.py
+++ b/Framework/Built_In_Automation/Shared_Resources/secrets.py
@@ -70,21 +70,23 @@ class Secret:
         
         try:
             test_id = None
-            step_id = None
             if sr.Test_Shared_Variables("zeuz_current_tc"):
                 current_tc = sr.Get_Shared_Variables("zeuz_current_tc")
                 if isinstance(current_tc, dict) and "testcase_no" in current_tc:
                     test_id = current_tc["testcase_no"]
-            if sr.Test_Shared_Variables("zeuz_current_step"):
-                current_step = sr.Get_Shared_Variables("zeuz_current_step")
-                if isinstance(current_step, dict) and "step_id" in current_step:
-                    step_id = current_step["step_id"]
-            
+
+            step_data = sr.Get_Shared_Variables(CommonUtil.dont_prettify_on_server[0])
+            if step_data and isinstance(step_data, list) and len(step_data) >= int(CommonUtil.current_action_no):
+                current_action = step_data[int(CommonUtil.current_action_no) - 1]
+                action_details = []
+                for action in current_action:
+                    if action and len(action) >= 3:
+                        action_details.append({"left": action[0], "middle": action[1], "right": action[2]})
             params = {}
             if test_id:
                 params["test_id"] = test_id
-            if step_id:
-                params["step_id"] = step_id
+            if action_details:
+                params["action_details"] = json.dumps({"values": action_details, "extra": "{}"})
 
             CommonUtil.ExecLog(sModuleInfo, f"Fetching secret '{key_name}' from server", 0)
             

--- a/Framework/Built_In_Automation/Shared_Resources/secrets.py
+++ b/Framework/Built_In_Automation/Shared_Resources/secrets.py
@@ -16,8 +16,7 @@ Example:
 import json
 import base64
 import inspect
-from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import padding
@@ -26,6 +25,9 @@ from cryptography.hazmat.primitives.padding import PKCS7
 
 from Framework.Utilities import CommonUtil, RequestFormatter
 from Framework.Built_In_Automation.Shared_Resources import BuiltInFunctionSharedResources as sr
+
+
+from settings import ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR
 
 
 MODULE_NAME = inspect.getmodulename(__file__)
@@ -44,7 +46,7 @@ class Secret:
     
     def __init__(self):
         self._cache: Dict[str, str] = {}
-        self._private_key_path = Path.home() / "zeuz_node_downloads" / "private_key.pem"
+        self._private_key_folder = ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR
         
     def __getitem__(self, key_name: str) -> str:
         """
@@ -148,24 +150,32 @@ class Secret:
             raise KeyError(f"Failed to retrieve secret '{key_name}': {str(e)}")
 
     
-    def _load_private_key(self):
+    def _load_private_keys(self):
         sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
         
         try:
-            if not self._private_key_path.exists():
+            if not self._private_key_folder.exists():
                 CommonUtil.ExecLog(
                     sModuleInfo,
-                    f"Private key not found at {self._private_key_path}",
+                    f"Private key folder not found at {self._private_key_folder}",
                     3
                 )
-                raise FileNotFoundError(f"Private key not found at {self._private_key_path}")
+                raise FileNotFoundError(f"Private key folder not found at {self._private_key_folder}")
             
-            with open(self._private_key_path, 'rb') as f:
-                return serialization.load_pem_private_key(f.read(), password=None)
+            private_keys = []
+            for pem_file in self._private_key_folder.glob("*.pem"):
+                with open(pem_file, 'rb') as f:
+                    private_key = serialization.load_pem_private_key(f.read(), password=None)
+                    private_keys.append(private_key)
+            
+            if not private_keys:
+                raise FileNotFoundError(f"No .pem files found in {self._private_key_folder}")
+            
+            return private_keys
         except Exception as e:
             CommonUtil.ExecLog(
                 sModuleInfo,
-                f"Failed to load private key: {str(e)}",
+                f"Failed to load private keys: {str(e)}",
                 3
             )
             raise
@@ -180,32 +190,38 @@ class Secret:
         Returns:
             Decrypted plaintext string
         """
-        private_key = self._load_private_key()
+        private_keys = self._load_private_keys()
         
         decoded_data = base64.b64decode(encrypted_data)
         data = json.loads(decoded_data.decode('utf-8'))
         
         encrypted_aes_key = base64.b64decode(data['encryptedKey'])
-        aes_key = private_key.decrypt(
-            encrypted_aes_key,
-            padding.OAEP(
-                mgf=padding.MGF1(algorithm=hashes.SHA256()),
-                algorithm=hashes.SHA256(),
-                label=None
-            )
-        )
-        
         iv = base64.b64decode(data['iv'])
         encrypted_content = base64.b64decode(data['encryptedData'])
         
-        cipher = Cipher(algorithms.AES(aes_key), modes.CBC(iv))
-        decryptor = cipher.decryptor()
-        decrypted_padded = decryptor.update(encrypted_content) + decryptor.finalize()
+        for private_key in private_keys:
+            try:
+                aes_key = private_key.decrypt(
+                    encrypted_aes_key,
+                    padding.OAEP(
+                        mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                        algorithm=hashes.SHA256(),
+                        label=None
+                    )
+                )
+                
+                cipher = Cipher(algorithms.AES(aes_key), modes.CBC(iv))
+                decryptor = cipher.decryptor()
+                decrypted_padded = decryptor.update(encrypted_content) + decryptor.finalize()
+                
+                unpadder = PKCS7(128).unpadder()
+                decrypted = unpadder.update(decrypted_padded) + unpadder.finalize()
+                
+                return decrypted.decode('utf-8')
+            except Exception:
+                continue
         
-        unpadder = PKCS7(128).unpadder()
-        decrypted = unpadder.update(decrypted_padded) + unpadder.finalize()
-        
-        return decrypted.decode('utf-8')
+        raise Exception("No private key could decrypt the data")
     
     def clear_cache(self, key_name: Optional[str] = None):
         """

--- a/Framework/Built_In_Automation/Web/Selenium/utils.py
+++ b/Framework/Built_In_Automation/Web/Selenium/utils.py
@@ -18,10 +18,7 @@ from datetime import timedelta
 import struct
 import urllib.request
 from rich.progress import Progress
-
-
-# ZeuZ Node Downloads base directory
-ZEUZ_NODE_DOWNLOADS_DIR = Path.home() / "zeuz_node_downloads"
+from settings import ZEUZ_NODE_DOWNLOADS_DIR
 
 
 class ChromeForTesting:

--- a/Framework/deploy_handler/long_poll_handler.py
+++ b/Framework/deploy_handler/long_poll_handler.py
@@ -4,10 +4,13 @@ from typing import Any, Callable
 import traceback
 import time
 import random
+import json
 import requests
 from colorama import Fore
+from pathlib import Path
+from urllib.parse import urlparse
 
-from Framework.Utilities import RequestFormatter
+from Framework.Utilities import RequestFormatter, ConfigModule, CommonUtil
 from Framework.node_server_state import STATE
 from concurrent.futures import ThreadPoolExecutor
 
@@ -20,6 +23,8 @@ class DeployHandler:
 
     COMMAND_DONE = b"DONE"
     COMMAND_CANCEL = b"CANCEL"
+    COMMAND_KEY_REQUEST = b"KEY_REQUEST"
+    COMMAND_PRIVATE_KEY = b"PRIVATE_KEY"
     ERROR_PREFIX = b"error"
 
     def __init__(
@@ -50,6 +55,16 @@ class DeployHandler:
             # Run cancelled by the user/service.
             self.cancel_callback()
             return False
+        
+        elif message.startswith(b'{"command":"KEY_REQUEST"'):
+            # Handle key request from server
+            self.handle_key_request(message)
+            return False
+        
+        elif message.startswith(b'{"command":"PRIVATE_KEY"'):
+            # Handle private key received from server
+            self.handle_private_key(message)
+            return False
 
         self.response_callback(message)
         return False
@@ -59,6 +74,193 @@ class DeployHandler:
         print(error)
         if self.backoff_time < 6:
             self.backoff_time += 1
+
+    def handle_key_request(self, message: bytes) -> None:
+        """
+        Handle KEY_REQUEST command.
+        Server is asking this node to share its private key that matches the provided public key.
+        """
+        try:
+            payload = json.loads(message)
+            request_id = payload["request_id"]
+            public_key_pem = payload["public_key"]
+            receiver_node_ids = payload["receiver_node_ids"]
+            
+            print(f"[key-request] Received request {request_id} to share key with {receiver_node_ids}")
+            
+            # Find the private key that matches the provided public key
+            private_key_pem = self.get_private_key_matching_public_key(public_key_pem)
+            
+            if private_key_pem:
+                # Respond to the key request immediately - no need for separate distribute call!
+                self.respond_to_key_request(request_id, private_key_pem)
+            else:
+                print("[key-request] ERROR: No private key found matching the provided public key")
+        except Exception as e:
+            print(f"[key-request] Error handling key request: {e}")
+            traceback.print_exc()
+
+    def handle_private_key(self, message: bytes) -> None:
+        """
+        Handle PRIVATE_KEY command.
+        Server is sending us a private key.
+        """
+        try:
+            payload = json.loads(message)
+            key_id = payload["key_id"]
+            private_key_pem = payload["private_key"]
+            
+            print(f"[private-key] Received key {key_id}")
+            
+            # Save the private key securely
+            self.save_private_key(key_id, private_key_pem)
+            
+            print(f"[private-key] Key {key_id} saved successfully")
+        except Exception as e:
+            print(f"[private-key] Error handling private key: {e}")
+            traceback.print_exc()
+
+    def get_private_key_matching_public_key(self, public_key_pem: str) -> str | None:
+        """
+        Find and retrieve the private key that corresponds to the provided public key.
+        Returns the private key in PEM format, or None if no matching key exists.
+        """
+        try:
+            from settings import ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR
+            from cryptography.hazmat.primitives import serialization
+            
+            key_folder = Path(ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR)
+            if not key_folder.exists():
+                print("[key-request] Key folder does not exist")
+                return None
+            
+            # Parse the provided public key
+            try:
+                target_public_key = serialization.load_pem_public_key(
+                    public_key_pem.encode('utf-8')
+                )
+                target_public_key_bytes = target_public_key.public_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PublicFormat.SubjectPublicKeyInfo
+                )
+            except Exception as e:
+                print(f"[key-request] Error parsing provided public key: {e}")
+                return None
+            
+            # Get all PEM files
+            pem_files = list(key_folder.glob("*.pem"))
+            
+            if not pem_files:
+                print("[key-request] No private key files found")
+                return None
+            
+            # Search through all keys to find matching private key
+            for pem_file in pem_files:
+                try:
+                    with open(pem_file, 'rb') as f:
+                        private_key_bytes = f.read()
+                        
+                    # Load the private key
+                    private_key = serialization.load_pem_private_key(
+                        private_key_bytes, 
+                        password=None
+                    )
+                    
+                    # Extract its public key
+                    derived_public_key = private_key.public_key()
+                    derived_public_key_bytes = derived_public_key.public_bytes(
+                        encoding=serialization.Encoding.PEM,
+                        format=serialization.PublicFormat.SubjectPublicKeyInfo
+                    )
+                    
+                    # Compare public keys
+                    if derived_public_key_bytes == target_public_key_bytes:
+                        print(f"[key-request] Found matching private key: {pem_file.name}")
+                        return private_key_bytes.decode('utf-8')
+                        
+                except Exception as e:
+                    print(f"[key-request] Error reading key file {pem_file.name}: {e}")
+                    continue
+            
+            print("[key-request] No private key matches the provided public key")
+            return None
+            
+        except Exception as e:
+            print(f"[key-request] Error searching for matching private key: {e}")
+            traceback.print_exc()
+            return None
+
+    def save_private_key(self, key_id: str, private_key_pem: str) -> None:
+        """
+        Save the received private key to encrypted storage.
+        This key is saved to the same location where generated keys are stored.
+        """
+        try:
+            from settings import ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR
+            from cryptography.hazmat.primitives import serialization
+            from datetime import datetime as dt
+            
+            key_folder = Path(ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR)
+            key_folder.mkdir(parents=True, exist_ok=True)
+            
+            # Validate the private key
+            private_key = serialization.load_pem_private_key(
+                private_key_pem.encode('utf-8'),
+                password=None,
+            )
+            
+            # Save with descriptive filename
+            timestamp = dt.now().strftime("%Y%m%d_%H%M%S")
+            key_filename = f"received_key_{key_id}_{timestamp}.pem"
+            key_path = key_folder / key_filename
+            
+            # Save the key
+            with open(key_path, 'wb') as f:
+                f.write(private_key.private_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PrivateFormat.PKCS8,
+                    encryption_algorithm=serialization.NoEncryption()
+                ))
+            
+            print(f"[private-key] Saved to: {key_path}")
+        except Exception as e:
+            print(f"[private-key] Error saving private key: {e}")
+            traceback.print_exc()
+
+    def respond_to_key_request(self, request_id: str, private_key_pem: str) -> None:
+        """
+        Respond to a key request - server will automatically distribute to receivers.
+        """
+        try:
+            server_url = urlparse(
+                ConfigModule.get_config_value("Authentication", "server_address")
+            )
+            api_url = f"{server_url.scheme}://{server_url.netloc}/zsvc/deploy/v1/respond-to-key-request"
+            
+            # Get node ID
+            node_id = CommonUtil.MachineInfo().getLocalUser().lower()
+            
+            response = RequestFormatter.request(
+                "post",
+                api_url,
+                json_data={
+                    "request_id": request_id,
+                    "donor_node_id": node_id,
+                    "private_key": private_key_pem
+                },
+                verify=False
+            )
+            
+            if response.ok:
+                result = response.json()
+                success_count = result.get('success_count', 0)
+                print(f"[key-request] Successfully distributed key to {success_count} receiver nodes")
+            else:
+                print(f"[key-request] Failed to respond to key request: {response.status_code}")
+                print(f"[key-request] Response: {response.text}")
+        except Exception as e:
+            print(f"[key-request] Error responding to key request: {e}")
+            traceback.print_exc()
 
     def run(self, host: str) -> None:
         reconnect = False

--- a/Framework/deploy_handler/long_poll_handler.py
+++ b/Framework/deploy_handler/long_poll_handler.py
@@ -57,12 +57,10 @@ class DeployHandler:
             return False
         
         elif message.startswith(b'{"command":"KEY_REQUEST"'):
-            # Handle key request from server
             self.handle_key_request(message)
             return False
         
         elif message.startswith(b'{"command":"PRIVATE_KEY"'):
-            # Handle private key received from server
             self.handle_private_key(message)
             return False
 
@@ -85,14 +83,11 @@ class DeployHandler:
             request_id = payload["request_id"]
             public_key_pem = payload["public_key"]
             receiver_node_ids = payload["receiver_node_ids"]
-            
             print(f"[key-request] Received request {request_id} to share key with {receiver_node_ids}")
             
-            # Find the private key that matches the provided public key
             private_key_pem = self.get_private_key_matching_public_key(public_key_pem)
             
             if private_key_pem:
-                # Respond to the key request immediately - no need for separate distribute call!
                 self.respond_to_key_request(request_id, private_key_pem)
             else:
                 print("[key-request] ERROR: No private key found matching the provided public key")
@@ -112,7 +107,6 @@ class DeployHandler:
             
             print(f"[private-key] Received key {key_id}")
             
-            # Save the private key securely
             self.save_private_key(key_id, private_key_pem)
             
             print(f"[private-key] Key {key_id} saved successfully")
@@ -121,10 +115,6 @@ class DeployHandler:
             traceback.print_exc()
 
     def get_private_key_matching_public_key(self, public_key_pem: str) -> str | None:
-        """
-        Find and retrieve the private key that corresponds to the provided public key.
-        Returns the private key in PEM format, or None if no matching key exists.
-        """
         try:
             from settings import ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR
             from cryptography.hazmat.primitives import serialization
@@ -176,7 +166,12 @@ class DeployHandler:
                     # Compare public keys
                     if derived_public_key_bytes == target_public_key_bytes:
                         print(f"[key-request] Found matching private key: {pem_file.name}")
-                        return private_key_bytes.decode('utf-8')
+                        # Return the private key in traditional RSA PRIVATE KEY format
+                        return private_key.private_bytes(
+                            encoding=serialization.Encoding.PEM,
+                            format=serialization.PrivateFormat.TraditionalOpenSSL,
+                            encryption_algorithm=serialization.NoEncryption()
+                        ).decode('utf-8')
                         
                 except Exception as e:
                     print(f"[key-request] Error reading key file {pem_file.name}: {e}")
@@ -198,27 +193,22 @@ class DeployHandler:
         try:
             from settings import ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR
             from cryptography.hazmat.primitives import serialization
-            from datetime import datetime as dt
             
             key_folder = Path(ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR)
             key_folder.mkdir(parents=True, exist_ok=True)
             
-            # Validate the private key
             private_key = serialization.load_pem_private_key(
                 private_key_pem.encode('utf-8'),
                 password=None,
             )
             
-            # Save with descriptive filename
-            timestamp = dt.now().strftime("%Y%m%d_%H%M%S")
-            key_filename = f"received_key_{key_id}_{timestamp}.pem"
+            key_filename = f"received-{key_id}.pem"
             key_path = key_folder / key_filename
             
-            # Save the key
             with open(key_path, 'wb') as f:
                 f.write(private_key.private_bytes(
                     encoding=serialization.Encoding.PEM,
-                    format=serialization.PrivateFormat.PKCS8,
+                    format=serialization.PrivateFormat.TraditionalOpenSSL,
                     encryption_algorithm=serialization.NoEncryption()
                 ))
             
@@ -243,7 +233,7 @@ class DeployHandler:
             response = RequestFormatter.request(
                 "post",
                 api_url,
-                json_data={
+                json={
                     "request_id": request_id,
                     "donor_node_id": node_id,
                     "private_key": private_key_pem

--- a/node_cli.py
+++ b/node_cli.py
@@ -31,6 +31,10 @@ from rich import traceback
 from urllib3.exceptions import InsecureRequestWarning
 import uvicorn
 from Framework.Built_In_Automation.Web.Selenium.utils import ChromeExtensionDownloader
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+
+from settings import ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR
 
 
 print(
@@ -645,7 +649,6 @@ def update_machine(dependency, should_print=True):
         if data["registered"]:
             if should_print:
                 rich_print = console.print
-                # rich_print(":green_circle: Zeuz Node is online: ", end="")
                 rich_print(":green_circle: " + data["name"], style="bold cyan", end="")
                 print(" is online\n")
                 CommonUtil.ExecLog(
@@ -728,6 +731,151 @@ def get_folder_creation_time(folder_path):
     return dt.fromtimestamp(creation_time).date()
 
 
+def generate_rsa_key():
+    """Generate a new RSA private key and save it to the rsa_private_keys folder."""
+    console = Console()
+    
+    key_folder = ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR
+    key_folder.mkdir(parents=True, exist_ok=True)
+    
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+    
+    timestamp = dt.now().strftime("%Y%m%d_%H%M%S")
+    key_filename = f"private_key_{timestamp}.pem"
+    key_path = key_folder / key_filename
+    
+    # Save private key
+    with open(key_path, 'wb') as f:
+        f.write(private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption()
+        ))
+    
+    # Generate public key
+    public_key = private_key.public_key()
+    public_key_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    ).decode('utf-8')
+    
+    console.print(f"\n[green]✓[/green] RSA private key generated successfully!")
+    console.print(f"[cyan]Location:[/cyan] {key_path}")
+    console.print(f"\n[cyan]Public Key:[/cyan]")
+    console.print(public_key_pem)
+    
+    return key_path
+
+
+def add_existing_rsa_key(key_content: str):
+    """Copy an existing RSA private key to the rsa_private_keys folder."""
+    console = Console()
+
+    key_folder = ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR
+    key_folder.mkdir(parents=True, exist_ok=True)
+    
+    try:
+        private_key = serialization.load_pem_private_key(
+            key_content.encode('utf-8'),
+            password=None,
+        )
+    except Exception as e:
+        console.print(f"[red]Error:[/red] Invalid PEM private key. {e}")
+        return False
+    
+    new_public_key = private_key.public_key()
+    new_public_key_pem = new_public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo
+    ).decode('utf-8')
+    
+    pem_files = list(key_folder.glob("*.pem"))
+    for pem_file in pem_files:
+        try:
+            with open(pem_file, 'rb') as f:
+                existing_private_key = serialization.load_pem_private_key(f.read(), password=None)
+            existing_public_key = existing_private_key.public_key()
+            existing_public_key_pem = existing_public_key.public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo
+            ).decode('utf-8')
+            if existing_public_key_pem == new_public_key_pem:
+                console.print(f"[yellow]Warning:[/yellow] This private key already exists as {pem_file.name}. Not adding duplicate.")
+                return False
+        except Exception as e:
+            console.print(f"[red]Error checking existing key {pem_file.name}:[/red] {e}")
+            continue
+    
+    # Copy the key with a timestamp
+    timestamp = dt.now().strftime("%Y%m%d_%H%M%S")
+    new_filename = f"imported_key_{timestamp}.pem"
+    new_key_path = key_folder / new_filename
+    
+    with open(new_key_path, 'wb') as f:
+        f.write(private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption()
+        ))
+    
+    console.print(f"\n[green]✓[/green] Private key imported successfully!")
+    console.print(f"[cyan]To:[/cyan] {new_key_path}")
+    
+    # Show the public key
+    console.print(f"\n[cyan]Public Key:[/cyan]")
+    console.print(new_public_key_pem)
+    
+    return True
+
+
+def show_existing_rsa_keys():
+    """List all existing RSA private keys and show their public keys."""
+    console = Console()
+
+    key_folder = ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR
+
+    if not key_folder.exists():
+        console.print(f"[yellow]![/yellow] No private keys folder found at: {key_folder}")
+        console.print("[yellow]![/yellow] Use --generate-key to create a new key.")
+        return
+    
+    pem_files = list(key_folder.glob("*.pem"))
+    
+    if not pem_files:
+        console.print(f"[yellow]![/yellow] No private keys found in: {key_folder}")
+        console.print("[yellow]![/yellow] Use --generate-key to create a new key.")
+        return
+    
+    console.print(f"\n[cyan]Found {len(pem_files)} private key(s) in:[/cyan] {key_folder}\n")
+    
+    for idx, pem_file in enumerate(pem_files, 1):
+        console.print(f"[bold cyan]Key #{idx}:[/bold cyan] {pem_file.name}")
+        console.print(f"[dim]Path:[/dim] {pem_file}")
+        
+        try:
+            with open(pem_file, 'rb') as f:
+                private_key = serialization.load_pem_private_key(f.read(), password=None)
+            
+            # Generate and show public key
+            public_key = private_key.public_key()
+            public_key_pem = public_key.public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo
+            ).decode('utf-8')
+            
+            console.print(f"[dim]Public Key:[/dim]")
+            console.print(public_key_pem)
+            
+        except Exception as e:
+            console.print(f"[red]Error loading key:[/red] {e}")
+        
+        if idx < len(pem_files):
+            console.print("---")
+
+
 def command_line_args() -> Path | None:
     """
     This function handles command line arguments for configuring and running Zeuz Node.
@@ -761,6 +909,15 @@ def command_line_args() -> Path | None:
 
     Example 9 - Advanced options:
     python node_cli.py -spu -sbl -slg
+
+    Example 10 - Generate RSA private key:
+    python node_cli.py -gpk
+
+    Example 11 - Add existing RSA private key:
+    python node_cli.py -apk /path/to/private_key.pem
+
+    Example 12 - Show existing RSA keys and their public keys:
+    python node_cli.py -spk
 
     Use -h or --help to see full documentation of all available arguments.
     """
@@ -848,6 +1005,27 @@ def command_line_args() -> Path | None:
         metavar="",
     )
 
+    # RSA key management arguments
+    parser_object.add_argument(
+        "-gpk",
+        "--generate-private-key",
+        action="store_true",
+        help="Generate a new RSA private key for encrypting secrets",
+    )
+    parser_object.add_argument(
+        "-apk",
+        "--add-private-key",
+        action="store",
+        help="Add an existing RSA private key (provide content of the .pem file)",
+        metavar="",
+    )
+    parser_object.add_argument(
+        "-spk",
+        "--show-private-keys",
+        action="store_true",
+        help="Show all existing RSA private keys and their public keys",
+    )
+
     all_arguments = parser_object.parse_args()
 
     server = all_arguments.server
@@ -863,6 +1041,26 @@ def command_line_args() -> Path | None:
     # get the chrome extension download settings
     chrome_fetch = all_arguments.chrome_fetch
     chrome_cleanup = all_arguments.chrome_cleanup
+
+    # RSA key management options
+    generate_key = all_arguments.generate_private_key
+    add_key = all_arguments.add_private_key
+    show_keys = all_arguments.show_private_keys
+
+    # Handle RSA key management commands
+    if generate_key:
+        generate_rsa_key()
+        sys.exit(0)
+    
+    if add_key:
+        if add_existing_rsa_key(add_key):
+            sys.exit(0)
+        else:
+            sys.exit(1)
+    
+    if show_keys:
+        show_existing_rsa_keys()
+        sys.exit(0)
 
     # Update chrome extension download settings if specified
     if chrome_fetch is not None:

--- a/settings.py
+++ b/settings.py
@@ -7,7 +7,7 @@ from Framework.Utilities import ConfigModule
 # BASE_DIR or PROJECT_ROOT or Zeuz_Python_Node dir
 PROJECT_ROOT = Path(__file__).parent
 
-ZEUZ_NODE_ARTIFACTS_DIR = Path.home() / "zeuz"
+ZEUZ_NODE_ARTIFACTS_DIR = Path.home() / ".zeuz"
 ZEUZ_NODE_DOWNLOADS_DIR = ZEUZ_NODE_ARTIFACTS_DIR / "zeuz_node_downloads"
 ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR = ZEUZ_NODE_ARTIFACTS_DIR / "rsa_private_keys"
 

--- a/settings.py
+++ b/settings.py
@@ -7,7 +7,7 @@ from Framework.Utilities import ConfigModule
 # BASE_DIR or PROJECT_ROOT or Zeuz_Python_Node dir
 PROJECT_ROOT = Path(__file__).parent
 
-ZEUZ_NODE_ARTIFACTS_DIR = Path.home() / "zeuz_node_artifacts"
+ZEUZ_NODE_ARTIFACTS_DIR = Path.home() / "zeuz"
 ZEUZ_NODE_DOWNLOADS_DIR = ZEUZ_NODE_ARTIFACTS_DIR / "zeuz_node_downloads"
 ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR = ZEUZ_NODE_ARTIFACTS_DIR / "rsa_private_keys"
 

--- a/settings.py
+++ b/settings.py
@@ -7,6 +7,10 @@ from Framework.Utilities import ConfigModule
 # BASE_DIR or PROJECT_ROOT or Zeuz_Python_Node dir
 PROJECT_ROOT = Path(__file__).parent
 
+ZEUZ_NODE_ARTIFACTS_DIR = Path.home() / "zeuz_node_artifacts"
+ZEUZ_NODE_DOWNLOADS_DIR = ZEUZ_NODE_ARTIFACTS_DIR / "zeuz_node_downloads"
+ZEUZ_NODE_PRIVATE_RSA_KEYS_DIR = ZEUZ_NODE_ARTIFACTS_DIR / "rsa_private_keys"
+
 # AutomationLog dir
 AutomationLog_DIR = PROJECT_ROOT / "AutomationLog"
 


### PR DESCRIPTION
## Overview

This PR added ability to handle zeuz secret. This will allow to handle sensitive data more securely.

ZeuZ node will try to resolve %|secret['key_name']|%. It will send current test_id and step action data to server with request to access the desired key. If authenticated, server will return the encrypted value. Node will decrypt and use it. It will also ensure it will never be shown in logs or any other places. You need proper private key to decrypt value.

There are 3 new command line args has been added.

`-apk`: This can be used to add new private key
`-gpk`: This can be used to generate new private key
`-spk`: This can be used to see existing private key and their public key

Upd: Node now can handle private key sharing request. It also can receive private key from server.

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature 


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


