### PR TITLE
Added 40 seconds timeout so it retries on slow network

### DIFF
--- a/Framework/deploy_handler/long_poll_handler.py
+++ b/Framework/deploy_handler/long_poll_handler.py
@@ -314,7 +314,7 @@ class DeployHandler:
     def fetch(self, host) -> requests.Response | None:
         executor = ThreadPoolExecutor(max_workers=1)
         future = executor.submit(
-            lambda: RequestFormatter.request("get", host, verify=False, timeout=30)
+            lambda: RequestFormatter.request("get", host, verify=False, timeout=40)
         )
 
         while not future.done():

--- a/Framework/deploy_handler/long_poll_handler.py
+++ b/Framework/deploy_handler/long_poll_handler.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from Framework.Utilities import RequestFormatter, ConfigModule, CommonUtil
+from Framework.Utilities.RequestFormatter import REQUEST_TIMEOUT
 from Framework.node_server_state import STATE
 from concurrent.futures import ThreadPoolExecutor
 
@@ -304,7 +305,7 @@ class DeployHandler:
 
                 reconnect = False
                 server_online = True
-            except requests.exceptions.ReadTimeout:
+            except requests.exceptions.Timeout:
                 pass
             except Exception:
                 traceback.print_exc()
@@ -313,7 +314,7 @@ class DeployHandler:
     def fetch(self, host) -> requests.Response | None:
         executor = ThreadPoolExecutor(max_workers=1)
         future = executor.submit(
-            lambda: RequestFormatter.request("get", host, verify=False)
+            lambda: RequestFormatter.request("get", host, verify=False, timeout=30)
         )
 
         while not future.done():


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
On slow network node was taking infinite time to connect to node and was failing to run consequent debug or test. So, the timeout now set to 30 seconds. Now if network is slow then it will take at most 30 seconds to reconnect.
