### PR TITLE
SessionNotCreatedException in ubuntu

### DIFF
--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -686,10 +686,20 @@ def Open_Browser(browser, browser_options: BrowserOptions):
                 service = Service()
                 CommonUtil.ExecLog(sModuleInfo, "Using standard Chrome binaries", 1)
 
-            selenium_driver = webdriver.Chrome(
-                service=service,
-                options=options,
-            )
+            try:
+                selenium_driver = webdriver.Chrome(
+                    service=service,
+                    options=options,
+                )
+            except SessionNotCreatedException as e:
+                if "user data directory" in str(e).lower() and "already in use" in str(e).lower():
+                    options.add_argument(f"--no-sandbox")
+                    selenium_driver = webdriver.Chrome(
+                        service=service,
+                        options=options,
+                    )
+                else:
+                    raise
 
             # service = Service()
             # selenium_driver = webdriver.Chrome(


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
On ubuntu google chrome having permission issue and user directory is already being used issue. Adding sandbox argument fixes the issue. Other OS are not having issue. So add Exception caching. If this exception arises then it will try to add argument
