### PR TITLE
Multiple android device support

### DIFF
--- a/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
@@ -933,6 +933,7 @@ def start_appium_driver(
         if str(appium_details[device_id]["type"]).lower() == "android":
             # All Desired caps = https://appium.io/docs/en/writing-running-appium/caps/
             desired_caps["platformName"] = appium_details[device_id]["type"]  # Set platform name
+            desired_caps["udid"] = appium_details[device_id]["serial"]
             desired_caps["autoLaunch"] = "false"  # Do not launch application
             desired_caps["fullReset"] = "false"  # Do not reinstall application
             if no_reset:

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1260,6 +1260,7 @@ def send_dom_variables():
 def set_device_info_according_to_user_order(device_order, device_dict,  test_case_no, test_case_name, user_info_object, Userid, **kwargs):
     # Need to set device_info for browserstack here
     global device_info
+    device_order = [[i, i] for i in range(1, len(device_dict) + 1)]  # overriding zsvc return device order. zsvc only returns [[1,1]] without considering the number of devices available
     shared.Set_Shared_Variables("device_order", device_order)
     if isinstance(device_order, list):
         try:

--- a/server/mobile.py
+++ b/server/mobile.py
@@ -2,7 +2,6 @@ import hashlib
 import os
 import subprocess
 import base64
-import time
 from typing import Literal
 import asyncio
 
@@ -32,6 +31,7 @@ class DeviceInfo(BaseModel):
     """Model for device information."""
     serial: str
     status: str
+    name: str | None = None
     # model: str | None = None
     # product: str | None = None
 
@@ -42,33 +42,34 @@ def get_devices():
         # Get list of devices
         devices_output = run_adb_command(f"{ADB_PATH} devices -l")
         devices = []
-        
+
         # Parse adb devices output
-        for line in devices_output.split('\n')[1:]:  # Skip first line (header)
+        index = 1
+        for line in devices_output.split("\n")[1:]:  # Skip first line (header)
             if line.strip():
                 parts = line.split()
                 if len(parts) >= 2:
                     serial = parts[0]
                     status = parts[1]
+                    name = f"device {index}"
+                    index += 1
                     # model = run_adb_command(f"{ADB_PATH} -s {serial} shell getprop ro.product.model")
                     # product = run_adb_command(f"{ADB_PATH} -s {serial} shell getprop ro.product.name")
 
-                    devices.append(DeviceInfo(
-                        serial=serial,
-                        status=status
-                    ))
-                        
+                    devices.append(DeviceInfo(serial=serial, status=status, name=name))
+
         return devices
     except Exception as e:
         return []
 
+
 @router.get("/inspect")
-def inspect():
+def inspect(device_serial: str | None = None):
     """Get the Mobile DOM and screenshot."""
     try:
         # Capture UI and screenshot
-        capture_ui_dump()
-        capture_screenshot()
+        capture_ui_dump(device_serial=device_serial)
+        capture_screenshot(device_serial=device_serial)
 
         # Read XML file
         with open(UI_XML_PATH, 'r') as xml_file:
@@ -108,9 +109,12 @@ def run_adb_command(command):
         return f"Error: {e.stderr.strip()}"
 
 
-def capture_ui_dump():
+def capture_ui_dump(device_serial: str | None = None):
     """Capture the current UI hierarchy from the device"""
-    out = run_adb_command(f"{ADB_PATH} shell uiautomator dump /sdcard/ui.xml")
+    device_flag = f"-s {device_serial}" if device_serial else ""
+    out = run_adb_command(
+        f"{ADB_PATH} {device_flag} shell uiautomator dump /sdcard/ui.xml".strip()
+    )
     if out.startswith("Error:"):
         from Framework.Built_In_Automation.Mobile.CrossPlatform.Appium.BuiltInFunctions import appium_driver
         if appium_driver is None:
@@ -119,14 +123,19 @@ def capture_ui_dump():
         with open(UI_XML_PATH, 'w') as xml_file:
             xml_file.write(page_src)
     else:
-        out = run_adb_command(f"{ADB_PATH} pull /sdcard/ui.xml {UI_XML_PATH}")
+        out = run_adb_command(
+            f"{ADB_PATH} {device_flag} pull /sdcard/ui.xml {UI_XML_PATH}"
+        )
         if out.startswith("Error:"):
             return
 
 
-def capture_screenshot():
+def capture_screenshot(device_serial: str | None = None):
     """Capture the current UI hierarchy from the device"""
-    out = run_adb_command(f"{ADB_PATH} shell screencap -p /sdcard/screen.png")
+    device_flag = f"-s {device_serial}" if device_serial else ""
+    out = run_adb_command(
+        f"{ADB_PATH} {device_flag} shell screencap -p /sdcard/screen.png".strip()
+    )
     if out.startswith("Error:"):
         from Framework.Built_In_Automation.Mobile.CrossPlatform.Appium.BuiltInFunctions import appium_driver
         if appium_driver is None:
@@ -134,7 +143,9 @@ def capture_screenshot():
         full_screenshot_path = os.path.join(os.getcwd(), SCREENSHOT_PATH)
         appium_driver.save_screenshot(full_screenshot_path)
     else:
-        out = run_adb_command(f"{ADB_PATH} pull /sdcard/screen.png {SCREENSHOT_PATH}")
+        out = run_adb_command(
+            f"{ADB_PATH} {device_flag} pull /sdcard/screen.png {SCREENSHOT_PATH}"
+        )
         if out.startswith("Error:"):
             return
 


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
In the past it was not possible to work with multiple android devices. 
Added support for multiple android devices.
While creating new appium driver now we are passing udid so that we can uniquely identify each android emulator or device. 
Also device order are now dynamically calculated so that all android devices are available in device_info
Now the mobile server supports specific device related requests. So we can inspect and capture targeted device

<img width="1593" height="815" alt="image" src="https://github.com/user-attachments/assets/eee33180-92a3-4f3d-842f-d8a2e5e3b1a2" />


## Test Cases
https://dev.zeuz.ai/Home/ManageTestCases/Edit/TEST-491/

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
