### PR TITLE
Ctrl+V issue for modern js library input is now fixed

### DIFF
--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -1809,13 +1809,15 @@ def Keystroke_For_Element(data_set):
                     try:
                         if get_element:
                             selenium_driver.execute_script(
-                                "arguments[0].focus();", Element
-                            )
-                            selenium_driver.execute_script(
                                 """
-                                arguments[0].value = arguments[1];
-                                arguments[0].dispatchEvent(new Event('input', { bubbles: true }));
-                                arguments[0].dispatchEvent(new Event('change', { bubbles: true }));
+                                var el = arguments[0];
+                                var text = arguments[1];
+                                var nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+                                nativeInputValueSetter.call(el, text);
+                                el.dispatchEvent(new Event('input', { bubbles: true }));
+                                el.dispatchEvent(new Event('change', { bubbles: true }));
+                                el.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true }));
+                                el.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
                                 """,
                                 Element,
                                 pyperclip.paste(),
@@ -1823,10 +1825,14 @@ def Keystroke_For_Element(data_set):
                         else:
                             selenium_driver.execute_script(
                                 """
+                                var el = document.activeElement;
                                 var text = arguments[0];
-                                document.activeElement.value += text;
-                                document.activeElement.dispatchEvent(new Event('input', { bubbles: true }));
-                                document.activeElement.dispatchEvent(new Event('change', { bubbles: true }));
+                                var nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+                                nativeInputValueSetter.call(el, text);
+                                el.dispatchEvent(new Event('input', { bubbles: true }));
+                                el.dispatchEvent(new Event('change', { bubbles: true }));
+                                el.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true }));
+                                el.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
                                 """,
                                 pyperclip.paste(),
                             )


### PR DESCRIPTION
There was an issue with pasting text into input fields with `Ctrl+V` for some modern js library e.g. react.
So now pasting with js is more robust to paste into input fields for most of them.

### Test Covered:
- [TEST-12241](https://qa.zeuz.ai/Home/ManageTestCases/Edit/TEST-12241/#parentHorizontalTab2)

### Scenarios:
- Tried in [Outreach](https://accounts.outreach.io/) [Modern framework(react/vue) Passed]
- Tried in [ZeuZ](https://qa.zeuz.ai/) [Simple html Passed]
- Tried in [Firefish](https://test-current-enterprise.current.jobs/login.aspx) [asp.net Passed]