### PR TITLE
Bug 160 group installer password fails

### DIFF
--- a/Framework/install_handler/long_poll_handler.py
+++ b/Framework/install_handler/long_poll_handler.py
@@ -276,6 +276,12 @@ class InstallHandler:
                     }
                 )
             elif action == "group_install":
+
+                user_password = ""
+                if message.value.item:
+                    user_password = (
+                        getattr(message.value.item, "user_password", "") or ""
+                    )
                 await send_response(
                     {
                         "action": "group_install",
@@ -294,7 +300,14 @@ class InstallHandler:
                     if i["install_function"]
                 ]
                 for func in functions:
-                    await func()
+                    # Check if function accepts parameters
+                    sig = inspect.signature(func)
+                    if len(sig.parameters) > 0:
+                        # Function accepts parameters, pass user_password
+                        await func(user_password)
+                    else:
+                        # Function doesn't accept parameters, call without (backward compatibility)
+                        await func()
                 await send_response(
                     {
                         "action": "group_install",

--- a/Framework/install_handler/route.py
+++ b/Framework/install_handler/route.py
@@ -110,7 +110,7 @@ services = [
                 "os": ["darwin"],
                 "status_function": xcode.check_status,
                 "install_function": xcode.install,
-                "user_password": "yes",
+                "user_password": True,
             },
             {
                 "name": "Simulator",
@@ -121,7 +121,7 @@ services = [
                 "os": ["darwin"],
                 "status_function": simulator.check_status,
                 "install_function": simulator.install,
-                "user_password": "yes",
+                "user_password": True,
             },
         ],
     },
@@ -167,7 +167,7 @@ services = [
                 "os": ["windows", "linux", "darwin"],
                 "status_function": mozilla.check_status,
                 "install_function": mozilla.install,
-                "user_password": False,
+                "user_password": True,
             },
             {
                 "name": "Edge",
@@ -178,7 +178,7 @@ services = [
                 "os": ["windows", "linux", "darwin"],
                 "status_function": edge.check_status,
                 "install_function": edge.install,
-                "user_password": "yes",
+                "user_password": True,
             },
         ],
     },
@@ -198,7 +198,7 @@ services = [
                 "os": ["darwin"],
                 "status_function": macos_xcode.check_status,
                 "install_function": macos_xcode.install,
-                "user_password": "yes",
+                "user_password": True,
             }
         ],
     },
@@ -219,7 +219,7 @@ services = [
                 "os": ["windows"],
                 "status_function": inspector.check_status,
                 "install_function": inspector.install,
-                "user_password": "no",
+                "user_password": False,
             }
         ],
     },

--- a/Framework/install_handler/web/edge.py
+++ b/Framework/install_handler/web/edge.py
@@ -679,6 +679,7 @@ async def _verify_edge_installation():
 
 
 async def install(user_password: str = "") -> bool:
+
    """Main function to install Microsoft Edge"""
    print("[installer][web-edge] Installing Microsoft Edge...")
    


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix




## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This PR fixes the bug of not showing the user password modal for group installation.  Now the password modal will pop up for group installation if one or more items in the group requires password to install.


## ZeuZ Ticket

Link: https://dev.zeuz.ai/Home/EditBug/BUG-160/
