### PR TITLE
[BUG-195] Fix MySQL Connector package version causing installation error on Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ dependencies = [
     "snowflake-connector-python>=3.12.0",
     "pyopenssl>=23.0.0",
     "pymysql>=1.1.2",
-    "mysql-connector-python>=9.5.0",
+    "mysql-connector-python==9.5.0",
     "oracledb>=3.4.1",
     "androguard>=4.1.2",
 ]


### PR DESCRIPTION
### Issue

- A recent update (9.6.0) to the `mysql-connector-python` library does not include Windows
- This faulty version causes an error during package installation in ZeuZ Node

### Solution

- The version has been locked to the last known working version (9.5.0) of the package, to prevent fetching the faulty version
- The fix has been tested on Windows and installation completes successfully