### PR TITLE
[BUG-203] Disable Step Action is not working inside the step for_loop execution

### DIFF
--- a/Framework/Built_In_Automation/Sequential_Actions/sequential_actions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/sequential_actions.py
@@ -747,6 +747,11 @@ def for_loop_action(step_data, data_set_no):
                     inner_skip = list(set(inner_skip + skip))
                     outer_skip = list(set(outer_skip + inner_skip))
 
+                    if step_exit_pass_called or step_exit_fail_called:
+                        step_exit_pass_called = False
+                        step_exit_fail_called = False
+                        break
+
                     if result == "passed" and data_set_index in exit_loop_and_cont["pass"][step_cnt]:
                         step_exit_fail_called = False
                         step_exit_pass_called = False
@@ -818,10 +823,6 @@ def for_loop_action(step_data, data_set_no):
                             CommonUtil.ExecLog(sModuleInfo, "Condition matched. Continuing to next iteration", 1)
                             cont_break = True
                             break
-
-                    if step_exit_fail_called or step_exit_pass_called:
-                        die = True
-                        break
 
                 if die or cont_break:
                     break

--- a/Framework/Built_In_Automation/Sequential_Actions/sequential_actions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/sequential_actions.py
@@ -596,7 +596,7 @@ def for_loop_action(step_data, data_set_no):
                 values = get_data_set_nums(sr.get_previous_response_variables_in_strings(row[2].strip()), step_loop)
                 if step_loop:
                     loop_steps = [list(range(len(CommonUtil.all_step_dataset[i]))) if i in values else [] for i in list(range(len(CommonUtil.all_step_dataset)))]
-                    CommonUtil.disabled_step += [i+1 for i in values]
+                    CommonUtil.loop_consumed_step += [i+1 for i in values]
                 else:
                     loop_steps[step_index] += values
                 # outer_skip += loop_this_data_sets
@@ -711,6 +711,13 @@ def for_loop_action(step_data, data_set_no):
             sr.Set_Shared_Variables(each_varname, each_val)
             for step_cnt, each_step in enumerate(loop_steps):
                 if len(each_step) == 0: continue
+                if (step_cnt + 1) in CommonUtil.disabled_step:
+                    CommonUtil.ExecLog(
+                        sModuleInfo,
+                        "STEP-%s is disabled. Skipping execution inside step loop" % (step_cnt + 1),
+                        2
+                    )
+                    continue
                 inner_skip = []
                 outer_skip = each_step
                 CommonUtil.current_step_no = str(step_cnt+1)
@@ -746,11 +753,6 @@ def for_loop_action(step_data, data_set_no):
                     result, skip = Run_Sequential_Actions([data_set_index])
                     inner_skip = list(set(inner_skip + skip))
                     outer_skip = list(set(outer_skip + inner_skip))
-
-                    if step_exit_pass_called or step_exit_fail_called:
-                        step_exit_pass_called = False
-                        step_exit_fail_called = False
-                        break
 
                     if result == "passed" and data_set_index in exit_loop_and_cont["pass"][step_cnt]:
                         step_exit_fail_called = False
@@ -823,7 +825,9 @@ def for_loop_action(step_data, data_set_no):
                             CommonUtil.ExecLog(sModuleInfo, "Condition matched. Continuing to next iteration", 1)
                             cont_break = True
                             break
-
+                    if step_exit_fail_called or step_exit_pass_called:
+                        die = True
+                        break
                 if die or cont_break:
                     break
             if die:

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -599,7 +599,7 @@ def run_all_test_steps_in_a_test_case(
             sTestStepStartTime = datetime.fromtimestamp(TestStepStartTime, tz=pytz.UTC).strftime("%Y-%m-%d %H:%M:%S.%f")
             WinMemBegin = CommonUtil.PhysicalAvailableMemory()  # get available memory
 
-            if StepSeq in CommonUtil.disabled_step or not this_step['step_enable']:
+            if StepSeq in CommonUtil.disabled_step or StepSeq in CommonUtil.loop_consumed_step or not this_step['step_enable']:
                 CommonUtil.ExecLog(sModuleInfo, "STEP-%s is disabled" % StepSeq, 2)
                 sStepResult = "skipped"
             elif CommonUtil.testcase_exit:
@@ -2008,6 +2008,7 @@ def main(device_dict, all_run_id_info):
                     }
                     set_device_info_according_to_user_order(device_order, device_dict, test_case_no, test_case_name, user_info_object, Userid, run_id=run_id)
                     CommonUtil.disabled_step = []
+                    CommonUtil.loop_consumed_step = []
                     CommonUtil.testcase_exit = ""
 
                     # Download test case and step attachments

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 # -*- coding: cp1252 -*-
 
 import selenium
@@ -147,7 +147,8 @@ custom_step_duration = ""
 jwt_token = ""
 run_cancel = ""
 run_cancelled = False
-disabled_step = []  # 1 based indexing
+disabled_step = []  # 1 based indexing (user requested step disable)
+loop_consumed_step = []  # 1 based indexing (steps executed via step loop)
 testcase_exit = ""
 max_char = 0
 compare_action_varnames = {"left":"Left", "right":"Right"}    # for labelling left and right variable names of compare action


### PR DESCRIPTION
## PR Type
Bug Fix

## PR Checklist
<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [x] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview

### Bug Description
The `disable step` action was not being respected inside step loop execution. When a step inside a loop disabled other steps (e.g., STEP-2 disables STEP-3 and STEP-4), those disabled steps would still execute within the loop, even though they were correctly skipped after the loop completed.

**Root Cause:**
- Single list (`disabled_step`) was used for two purposes: user intent (disable_step action) and loop bookkeeping (prevent re-running loop-consumed steps)
- Step loop executor had no check for `disabled_step` before executing steps
- Only the outer scheduler honored the `disabled_step` list

### Previous Behavior (Broken)
```
STEP-1: Loop through STEP-2 to STEP-5
  ├─ STEP-2 executes → disables STEP-3, STEP-4
  ├─ STEP-3 executes (should be skipped)
  ├─ STEP-4 executes (should be skipped)
  └─ STEP-5 executes
```
### New Behavior (Fixed)
```
STEP-1: Loop through STEP-2 to STEP-5
  ├─ STEP-2 executes → disables STEP-3, STEP-4
  ├─ STEP-3 skipped ✓ (disabled by user)
  ├─ STEP-4 skipped ✓ (disabled by user)
  └─ STEP-5 executes
```

## Changes Made

### 1. `Framework/Utilities/CommonUtil.py` 
**Added:** New list for loop bookkeeping
```python
disabled_step = []  
loop_consumed_step = [] 
```
**Purpose:** Separate user intent from system bookkeeping

---

### 2. `Framework/Built_In_Automation/Sequential_Actions/sequential_actions.py` 
**Changed:**
```python
# Before:
CommonUtil.disabled_step += [i+1 for i in values]

# After:
CommonUtil.loop_consumed_step += [i+1 for i in values]
```
**Purpose:** Use dedicated list for loop bookkeeping instead of mixing with user intent

---

### 3. `Framework/Built_In_Automation/Sequential_Actions/sequential_actions.py` 
**Added:** Check for disabled steps before executing in loop
```python
if (step_cnt + 1) in CommonUtil.disabled_step:
    CommonUtil.ExecLog(
        sModuleInfo,
        "STEP-%s is disabled. Skipping execution inside step loop" % (step_cnt + 1),
        2
    )
    continue
```
**Purpose:** Respect user-disabled steps during loop execution 

---

### 4. `Framework/MainDriverApi.py` 
**Changed:**
```python
# Before:
if StepSeq in CommonUtil.disabled_step or not this_step['step_enable']:

# After:
if StepSeq in CommonUtil.disabled_step or StepSeq in CommonUtil.loop_consumed_step or not this_step['step_enable']:
```
**Purpose:** Check both lists when skipping steps in outer scheduler

---

### 5. `Framework/MainDriverApi.py` 
**Added:** Reset loop bookkeeping list per test case
```python
CommonUtil.disabled_step = []
CommonUtil.loop_consumed_step = []  # New line
CommonUtil.testcase_exit = ""
```
**Purpose:** Clean state for each test case execution

---


## Test Cases
- [TEST-12471](https://qa.zeuz.ai/Home/ManageTestCases/Edit/TEST-12471/) 

## Files Changed
1. `Framework/Utilities/CommonUtil.py`
2. `Framework/Built_In_Automation/Sequential_Actions/sequential_actions.py`
3. `Framework/MainDriverApi.py`

<!-- Closes #[issue-number] -->
