### PR TITLE
Run cleanup tasks after each run_id completes

### DIFF
--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -93,6 +93,32 @@ device_info = {}
 failed_due_to_linked_fail = False
 
 
+def post_runid_cleanup():
+    """Run node cleanup tasks that should execute after each run_id."""
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+
+    try:
+        from Framework.Built_In_Automation.Web.Selenium.utils import (
+            ChromeExtensionDownloader,
+            ChromeForTesting,
+        )
+
+        ChromeForTesting().cleanup_old_versions()
+        ChromeExtensionDownloader().cleanup_extensions()
+        CommonUtil.ExecLog(
+            sModuleInfo,
+            "Completed post run_id cleanup for Chrome for Testing and Chrome extensions.",
+            1,
+        )
+    except Exception:
+        CommonUtil.ExecLog(
+            sModuleInfo,
+            "Post run_id cleanup failed. Continuing execution.",
+            2,
+        )
+        CommonUtil.debug_code_error(sys.exc_info())
+
+
 # sets server variable
 # TODO: remove, need alternative
 def set_server_variable(run_id, key, value):
@@ -2182,6 +2208,9 @@ def main(device_dict, all_run_id_info):
                     CommonUtil.run_cancelled = True
                 del CommonUtil.all_threads["run_cancel"]
             CommonUtil.run_cancelled = False
+
+            post_runid_cleanup()
+
             if ConfigModule.get_config_value("RunDefinition", "local_run") == "True":
                 input("[Local run] Press any key to finish")
 


### PR DESCRIPTION
### Motivation
- The Chrome-for-Testing and extension cleanup only ran during Chrome setup (e.g. at browser init) which meant old CfT versions and downloaded extensions could persist across run_id executions.
- Cleanup must be executed after a run_id finishes so node-level artifacts are pruned in the execution lifecycle instead of only at startup.
- Also tie the Chrome extension cleanup into the same post-run path to ensure both cleanup flows run together after each run.

### Description
- Added a new helper `post_runid_cleanup()` to `Framework/MainDriverApi.py` which imports `ChromeForTesting` and `ChromeExtensionDownloader` and invokes `cleanup_old_versions()` and `cleanup_extensions()` respectively, with guarded error handling and logging via `CommonUtil.ExecLog` and `CommonUtil.debug_code_error`.
- Hooked `post_runid_cleanup()` into the main run loop immediately after run_id finalization so cleanup runs after each run completes by calling `post_runid_cleanup()` in the run completion section of `main`.
- The change is implemented so failures during cleanup are non-fatal and only logged, preserving normal run completion behavior.

### Testing
- Compiled the modified modules to validate syntax with `python -m py_compile Framework/MainDriverApi.py Framework/Built_In_Automation/Web/Selenium/utils.py`, which succeeded (no syntax errors).
- Verified the new call location and function placement in `Framework/MainDriverApi.py` and confirmed the code change was applied without breaking imports.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699717ae5eb0832183d4a35f53a2065e)