### PR TITLE
[Task-2247] Named Browser Sessions For Dual-Driver Browser Instances

### DIFF
--- a/Framework/Built_In_Automation/Sequential_Actions/sequential_actions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/sequential_actions.py
@@ -177,8 +177,22 @@ def write_browser_logs():
     try:
         if str(sr.Get_Shared_Variables("zeuz_collect_browser_log")).strip().lower() in ("false", "no", "off", "disable"):
             return
+        drivers = []
+        if sr.Test_Shared_Variables("browser_sessions"):
+            browser_sessions = sr.Get_Shared_Variables("browser_sessions", log=False)
+            if isinstance(browser_sessions, dict):
+                drivers.extend(
+                    session.get("selenium_driver")
+                    for session in browser_sessions.values()
+                    if isinstance(session, dict) and session.get("selenium_driver")
+                )
         if sr.Test_Shared_Variables("selenium_driver"):
-            driver = sr.Get_Shared_Variables("selenium_driver")
+            drivers.append(sr.Get_Shared_Variables("selenium_driver"))
+        seen = set()
+        for driver in drivers:
+            if id(driver) in seen:
+                continue
+            seen.add(id(driver))
             for browser_log in driver.get_log("browser"):
                 CommonUtil.ExecLog(sModuleInfo, browser_log["message"], 6,print_Execlog=CommonUtil.show_browser_log)
     except Exception as e:
@@ -2500,6 +2514,13 @@ async def Action_Handler(_data_set, action_row, _bypass_bug=True):
         if result == "zeuz_failed":
             CommonUtil.ExecLog(sModuleInfo, "Can't find module for %s" % module, 3)
             return "zeuz_failed"
+        session_activator = getattr(eval(module), "_activate_browser_session_for_action", None)
+        if session_activator:
+            result = session_activator(data_set, function)
+            if inspect.iscoroutine(result):
+                result = await result
+            if result in failed_tag_list:
+                return result
         run_function = getattr(eval(module), function)  # create a reference to the function
         start_time = time.perf_counter()
         if pre_sleep:

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -46,6 +46,14 @@ from Framework.Built_In_Automation.Shared_Resources import (
 from Framework.Utilities.CommonUtil import passed_tag_list, failed_tag_list
 from . import locator as PlaywrightLocator
 from . import utils as PlaywrightUtils
+from Framework.Built_In_Automation.Web.utils import (
+    create_browser_session,
+    extract_session_name,
+    get_browser_session,
+    get_browser_sessions,
+    get_debug_port,
+    remove_browser_session,
+)
 from settings import ZEUZ_NODE_DOWNLOADS_DIR
 
 def _get_frame_locator():
@@ -58,6 +66,60 @@ def _get_frame_locator():
     except:
         # Variable doesn't exist yet
         return None
+
+
+def _set_active_playwright_session(session_name, session):
+    """Update module globals/shared variables for a selected Playwright session."""
+
+    global current_page, current_page_id, context, browser, playwright_instance
+
+    current_page = session.get("playwright_page")
+    context = session.get("playwright_context")
+    browser = session.get("playwright_browser")
+    playwright_instance = session.get("playwright_instance") or playwright_instance
+    current_page_id = session_name
+
+    sr.Set_Shared_Variables("playwright_page", current_page)
+    sr.Set_Shared_Variables("playwright_context", context)
+    sr.Set_Shared_Variables("playwright_browser", browser)
+    sr.Set_Shared_Variables("playwright_frame", session.get("playwright_frame"))
+    sr.Set_Shared_Variables("active_web_driver_type", "playwright")
+    if session.get("selenium_driver"):
+        sr.Set_Shared_Variables("selenium_driver", session["selenium_driver"])
+    CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
+
+
+def _save_current_playwright_frame(frame_locator):
+    if current_page_id:
+        sessions = get_browser_sessions()
+        if current_page_id in sessions:
+            sessions[current_page_id]["playwright_frame"] = frame_locator
+            sr.Set_Shared_Variables("browser_sessions", sessions)
+
+
+def _activate_browser_session_for_action(step_data, function_name=None):
+    """Select the requested browser session before running Playwright actions."""
+
+    session_name = extract_session_name(step_data)
+    if not session_name:
+        return "passed"
+
+    create_or_cleanup_actions = {
+        "Open_Browser",
+        "Go_To_Link",
+        "Tear_Down_Playwright",
+    }
+    if function_name in create_or_cleanup_actions:
+        return "passed"
+
+    existing_session = get_browser_session(session_name)
+    if not existing_session or not existing_session.get("playwright_page"):
+        sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+        CommonUtil.ExecLog(sModuleInfo, f"Browser session '{session_name}' not found", 3)
+        return "zeuz_failed"
+
+    _set_active_playwright_session(session_name, existing_session)
+    return "passed"
 
 
 def connect_selenium_to_playwright(port=9222):
@@ -129,48 +191,20 @@ def _handle_playwright_session(step_data):
     """
     global current_page, current_page_id, context, browser
     
-    # Parse session parameter
-    session_name = None
-    for left, mid, right in step_data:
-        left_l = left.strip().lower()
-        mid_l = mid.strip().lower()
-        right_v = right.strip()
-        
-        if mid_l == "optional parameter" and left_l == "session":
-            session_name = right_v
-            break
+    session_name = extract_session_name(step_data)
     
     # If session parameter is provided, switch to that session
     if session_name:
-        from Framework.Built_In_Automation.Web.utils import get_browser_session
         existing_session = get_browser_session(session_name)
         
         if existing_session and existing_session.get("playwright_page"):
-            # Session exists, use existing browser
-            current_page = existing_session["playwright_page"]
-            context = existing_session["playwright_context"]
-            browser = existing_session["playwright_browser"]
-            current_page_id = session_name
-            
-            # Update globals
-            globals().update({
-                'current_page': current_page,
-                'context': context,
-                'browser': browser,
-                'current_page_id': current_page_id
-            })
-            
-            # Update shared variables
-            sr.Set_Shared_Variables("playwright_page", current_page)
-            sr.Set_Shared_Variables("playwright_context", context)
-            sr.Set_Shared_Variables("playwright_browser", browser)
-            
+            _set_active_playwright_session(session_name, existing_session)
             sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
             CommonUtil.ExecLog(sModuleInfo, f"Using existing browser session: {session_name}", 1)
         else:
-            # Session doesn't exist
             sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
-            CommonUtil.ExecLog(sModuleInfo, f"Session '{session_name}' not found. Using current browser.", 2)
+            CommonUtil.ExecLog(sModuleInfo, f"Browser session '{session_name}' not found", 3)
+            raise ValueError(f"Browser session '{session_name}' not found")
     
     return session_name, current_page, current_page_id, context, browser
 
@@ -286,10 +320,7 @@ async def Open_Browser(step_data):
         }
         
         # Add remote debugging port for CDP connection with unique port per session
-        import hashlib
-        # Generate unique port based on page_id (range 9222-9322 to avoid conflicts)
-        port_hash = int(hashlib.md5(page_id.encode()).hexdigest(), 16)
-        unique_port = 9222 + (port_hash % 100)
+        unique_port = get_debug_port(page_id)
         all_args = args + [f"--remote-debugging-port={unique_port}"]
         CommonUtil.ExecLog(sModuleInfo, f"Using remote debugging port {unique_port} for session '{page_id}'", 1)
         if all_args:
@@ -346,6 +377,7 @@ async def Open_Browser(step_data):
             "context": context,
             "browser": browser,
             "playwright": playwright_instance,
+            "remote-debugging-port": unique_port,
         }
 
         # Navigate if URL provided
@@ -358,6 +390,7 @@ async def Open_Browser(step_data):
         sr.Set_Shared_Variables("playwright_context", context)
         sr.Set_Shared_Variables("playwright_browser", browser)
         sr.Set_Shared_Variables("element_wait", timeout / 1000)  # In seconds
+        sr.Set_Shared_Variables("active_web_driver_type", "playwright")
         
         # Set screenshot variables for CommonUtil.TakeScreenShot()
         CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
@@ -366,15 +399,15 @@ async def Open_Browser(step_data):
         selenium_driver = connect_selenium_to_playwright(port=unique_port)
 
         # Create browser session
-        from Framework.Built_In_Automation.Web.utils import create_browser_session
-        
         create_browser_session(
             session_name=page_id,
             selenium_driver=selenium_driver,
             playwright_page=current_page,
             playwright_browser=browser,
             playwright_context=context,
-            playwright_frame=None
+            playwright_frame=None,
+            playwright_instance=playwright_instance,
+            remote_debugging_port=unique_port,
         )
         CommonUtil.ExecLog(sModuleInfo, f"Created browser session: {page_id}", 5)
 
@@ -415,29 +448,10 @@ async def Go_To_Link(step_data):
         
         # Check if session exists and use it
         if session_name:
-            from Framework.Built_In_Automation.Web.utils import get_browser_session
             existing_session = get_browser_session(session_name)
             
             if existing_session and existing_session.get("playwright_page"):
-                # Session exists, use existing browser
-                current_page = existing_session["playwright_page"]
-                context = existing_session["playwright_context"]
-                browser = existing_session["playwright_browser"]
-                current_page_id = session_name
-                
-                # Update globals
-                globals().update({
-                    'current_page': current_page,
-                    'context': context,
-                    'browser': browser,
-                    'current_page_id': current_page_id
-                })
-                
-                # Update shared variables
-                sr.Set_Shared_Variables("playwright_page", current_page)
-                sr.Set_Shared_Variables("playwright_context", context)
-                sr.Set_Shared_Variables("playwright_browser", browser)
-                
+                _set_active_playwright_session(session_name, existing_session)
                 CommonUtil.ExecLog(sModuleInfo, f"Using existing browser session: {session_name}", 1)
             else:
                 # Session doesn't exist, open new browser with session name
@@ -493,6 +507,7 @@ async def Go_To_Link(step_data):
         
         # Reset frame context when navigating to a new URL
         sr.Set_Shared_Variables("playwright_frame", None)
+        _save_current_playwright_frame(None)
         
         CommonUtil.ExecLog(sModuleInfo, f"Navigated to: {url}", 1)
         return "passed"
@@ -534,7 +549,6 @@ async def Tear_Down_Playwright(step_data=None):
         
         # Handle session-specific teardown
         if session_name:
-            from Framework.Built_In_Automation.Web.utils import get_browser_session
             existing_session = get_browser_session(session_name)
             
             if existing_session and existing_session.get("playwright_page"):
@@ -543,22 +557,29 @@ async def Tear_Down_Playwright(step_data=None):
                     session_page = existing_session["playwright_page"]
                     session_context = existing_session["playwright_context"]
                     session_browser = existing_session["playwright_browser"]
+                    session_playwright = existing_session.get("playwright_instance")
+                    session_selenium = existing_session.get("selenium_driver")
                     
                     if session_page:
                         await session_page.close()
                     if session_context:
                         await session_context.close()
+                    if session_browser:
+                        await session_browser.close()
+                    if session_playwright:
+                        await session_playwright.stop()
+                    if session_selenium and session_selenium != "zeuz_failed":
+                        try:
+                            session_selenium.quit()
+                        except Exception:
+                            pass
                     
                     CommonUtil.ExecLog(sModuleInfo, f"Teared down session '{session_name}'", 1)
                 except Exception as e:
                     errMsg = f"Unable to tear down session '{session_name}'. may already been killed"
                     CommonUtil.ExecLog(sModuleInfo, errMsg, 2)
                 
-                # Remove session from browser_sessions
-                browser_sessions = sr.Get_Shared_Variables("browser_sessions", {})
-                if session_name in browser_sessions:
-                    del browser_sessions[session_name]
-                    sr.Set_Shared_Variables("browser_sessions", browser_sessions)
+                remove_browser_session(session_name)
                 
                 # Remove from playwright_details if present
                 if session_name in playwright_details:
@@ -588,16 +609,30 @@ async def Tear_Down_Playwright(step_data=None):
                             break
             else:
                 CommonUtil.ExecLog(sModuleInfo, f"Session '{session_name}' not found. Nothing to tear down.", 2)
+            return "passed"
         
         # Handle full teardown (backwards compatibility)
         else:
+            for session in get_browser_sessions().values():
+                if not (isinstance(session, dict) and session.get("playwright_page")):
+                    continue
+                try:
+                    if session.get("selenium_driver") and session.get("selenium_driver") != "zeuz_failed":
+                        session["selenium_driver"].quit()
+                except Exception:
+                    pass
+
             # Close all tracked pages/contexts
-            for page_id, details in playwright_details.items():
+            for page_id, details in list(playwright_details.items()):
                 try:
                     if details.get("page"):
                         await details["page"].close()
                     if details.get("context"):
                         await details["context"].close()
+                    if details.get("browser"):
+                        await details["browser"].close()
+                    if details.get("playwright"):
+                        await details["playwright"].stop()
                 except Exception:
                     pass
 
@@ -634,18 +669,26 @@ async def Tear_Down_Playwright(step_data=None):
             playwright_details = {}
             current_page_id = None
             
-            # Clear all browser sessions
-            sr.Set_Shared_Variables("browser_sessions", {})
+            # Clear Playwright-backed browser sessions without discarding Selenium-only sessions.
+            sessions = get_browser_sessions()
+            sessions = {
+                name: session
+                for name, session in sessions.items()
+                if not (isinstance(session, dict) and session.get("playwright_page"))
+            }
+            sr.Set_Shared_Variables("browser_sessions", sessions)
 
             CommonUtil.ExecLog(sModuleInfo, "Browser closed successfully", 1)
             return "passed"
+
+        return "passed"
 
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())
 
 
 @logger
-def Switch_Browser(step_data):
+async def Switch_Browser(step_data):
     """
     Switch between multiple browser instances/pages.
 
@@ -655,7 +698,7 @@ def Switch_Browser(step_data):
         switch browser      playwright action   switch browser
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
-    global current_page, current_page_id, context
+    global current_page, current_page_id, context, browser
 
     try:
         target_id = None
@@ -665,13 +708,21 @@ def Switch_Browser(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "input parameter":
-                if left_l in ("driver id", "page id", "driver tag"):
+            if mid_l in ("input parameter", "optional parameter"):
+                if left_l in ("driver id", "page id", "driver tag", "session"):
                     target_id = right_v
 
         if not target_id:
             CommonUtil.ExecLog(sModuleInfo, "No driver/page ID provided", 3)
             return "zeuz_failed"
+
+        existing_session = get_browser_session(target_id)
+        if existing_session and existing_session.get("playwright_page"):
+            _set_active_playwright_session(target_id, existing_session)
+            if current_page:
+                await current_page.bring_to_front()
+            CommonUtil.ExecLog(sModuleInfo, f"Switched to page: {target_id}", 1)
+            return "passed"
 
         if target_id not in playwright_details:
             CommonUtil.ExecLog(sModuleInfo, f"Page ID '{target_id}' not found", 3)
@@ -680,12 +731,14 @@ def Switch_Browser(step_data):
         details = playwright_details[target_id]
         current_page = details["page"]
         context = details["context"]
+        browser = details["browser"]
         current_page_id = target_id
 
-        current_page.bring_to_front()
+        await current_page.bring_to_front()
 
         sr.Set_Shared_Variables("playwright_page", current_page)
         sr.Set_Shared_Variables("playwright_context", context)
+        sr.Set_Shared_Variables("playwright_browser", browser)
         
         # Set screenshot variables for CommonUtil.TakeScreenShot()
         CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
@@ -1469,7 +1522,7 @@ async def get_element_info(step_data):
 #########################
 
 @logger
-def Navigate(step_data):
+async def Navigate(step_data):
     """
     Navigate browser (back, forward, refresh).
 
@@ -1507,13 +1560,13 @@ def Navigate(step_data):
             nav_options["timeout"] = timeout
 
         if direction in ("back", "go back"):
-            current_page.go_back(**nav_options)
+            await current_page.go_back(**nav_options)
             CommonUtil.ExecLog(sModuleInfo, "Navigated back", 1)
         elif direction in ("forward", "go forward"):
-            current_page.go_forward(**nav_options)
+            await current_page.go_forward(**nav_options)
             CommonUtil.ExecLog(sModuleInfo, "Navigated forward", 1)
         elif direction in ("refresh", "reload"):
-            current_page.reload(**nav_options)
+            await current_page.reload(**nav_options)
             CommonUtil.ExecLog(sModuleInfo, "Page reloaded", 1)
         else:
             CommonUtil.ExecLog(sModuleInfo, f"Unknown navigation direction: {direction}", 3)
@@ -1569,7 +1622,7 @@ def Get_Current_URL(step_data):
 #########################
 
 @logger
-def Scroll(step_data):
+async def Scroll(step_data):
     """
     Scroll the page in a direction.
 
@@ -1616,7 +1669,7 @@ def Scroll(step_data):
         elif direction == "left":
             delta_x = -pixels
 
-        current_page.mouse.wheel(delta_x, delta_y)
+        await current_page.mouse.wheel(delta_x, delta_y)
         CommonUtil.ExecLog(sModuleInfo, f"Scrolled {direction} by {pixels}px", 1)
         return "passed"
 
@@ -1844,7 +1897,7 @@ async def check_uncheck(step_data):
 #########################
 
 @logger
-def switch_window_or_tab(step_data):
+async def switch_window_or_tab(step_data):
     """
     Switch to a different window/tab.
 
@@ -1893,11 +1946,11 @@ def switch_window_or_tab(step_data):
 
         if switch_by_title:
             for page in pages:
-                page_title = page.title()
+                page_title = await page.title()
                 if partial_match:
                     if switch_by_title.lower() in page_title.lower():
                         current_page = page
-                        page.bring_to_front()
+                        await page.bring_to_front()
                         sr.Set_Shared_Variables("playwright_page", current_page)
                         CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
                         CommonUtil.ExecLog(sModuleInfo, f"Switched to tab: {page_title}", 1)
@@ -1905,7 +1958,7 @@ def switch_window_or_tab(step_data):
                 else:
                     if switch_by_title.lower() == page_title.lower():
                         current_page = page
-                        page.bring_to_front()
+                        await page.bring_to_front()
                         sr.Set_Shared_Variables("playwright_page", current_page)
                         CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
                         CommonUtil.ExecLog(sModuleInfo, f"Switched to tab: {page_title}", 1)
@@ -1917,10 +1970,10 @@ def switch_window_or_tab(step_data):
         elif switch_by_index is not None:
             if 0 <= switch_by_index < len(pages):
                 current_page = pages[switch_by_index]
-                current_page.bring_to_front()
+                await current_page.bring_to_front()
                 sr.Set_Shared_Variables("playwright_page", current_page)
                 CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
-                CommonUtil.ExecLog(sModuleInfo, f"Switched to tab index {switch_by_index}: {current_page.title()}", 1)
+                CommonUtil.ExecLog(sModuleInfo, f"Switched to tab index {switch_by_index}: {await current_page.title()}", 1)
                 return "passed"
             else:
                 CommonUtil.ExecLog(sModuleInfo, f"Invalid tab index: {switch_by_index}", 3)
@@ -1934,7 +1987,7 @@ def switch_window_or_tab(step_data):
 
 
 @logger
-def open_new_tab(step_data):
+async def open_new_tab(step_data):
     """
     Open a new browser tab.
 
@@ -1960,13 +2013,18 @@ def open_new_tab(step_data):
             if mid_l == "input parameter" and left_l in ("url", "link", "go to link"):
                 url = right_v
 
-        new_page = context.new_page()
+        new_page = await context.new_page()
         current_page = new_page
         sr.Set_Shared_Variables("playwright_page", current_page)
+        if current_page_id:
+            sessions = get_browser_sessions()
+            if current_page_id in sessions:
+                sessions[current_page_id]["playwright_page"] = current_page
+                sr.Set_Shared_Variables("browser_sessions", sessions)
         CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
 
         if url:
-            new_page.goto(url)
+            await new_page.goto(url)
             CommonUtil.ExecLog(sModuleInfo, f"Opened new tab with URL: {url}", 1)
         else:
             CommonUtil.ExecLog(sModuleInfo, "Opened new blank tab", 1)
@@ -1978,7 +2036,7 @@ def open_new_tab(step_data):
 
 
 @logger
-def close_tab(step_data):
+async def close_tab(step_data):
     """
     Close a browser tab.
 
@@ -2017,8 +2075,8 @@ def close_tab(step_data):
 
         if tab_title:
             for page in pages:
-                if tab_title.lower() in page.title().lower():
-                    page.close()
+                if tab_title.lower() in (await page.title()).lower():
+                    await page.close()
                     CommonUtil.ExecLog(sModuleInfo, f"Closed tab: {tab_title}", 1)
                     break
             else:
@@ -2026,7 +2084,7 @@ def close_tab(step_data):
                 return "zeuz_failed"
         elif tab_index is not None:
             if 0 <= tab_index < len(pages):
-                pages[tab_index].close()
+                await pages[tab_index].close()
                 CommonUtil.ExecLog(sModuleInfo, f"Closed tab at index {tab_index}", 1)
             else:
                 CommonUtil.ExecLog(sModuleInfo, f"Invalid tab index: {tab_index}", 3)
@@ -2034,7 +2092,7 @@ def close_tab(step_data):
         else:
             # Close current tab
             if current_page:
-                current_page.close()
+                await current_page.close()
                 CommonUtil.ExecLog(sModuleInfo, "Closed current tab", 1)
 
         # Switch to remaining tab if available
@@ -2042,6 +2100,11 @@ def close_tab(step_data):
         if pages:
             current_page = pages[-1]
             sr.Set_Shared_Variables("playwright_page", current_page)
+            if current_page_id:
+                sessions = get_browser_sessions()
+                if current_page_id in sessions:
+                    sessions[current_page_id]["playwright_page"] = current_page
+                    sr.Set_Shared_Variables("browser_sessions", sessions)
             CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
 
         return "passed"
@@ -2106,6 +2169,7 @@ async def switch_iframe(step_data):
             # In Playwright, we work with the main page directly
             # Store a flag or reset frame locator
             sr.Set_Shared_Variables("playwright_frame", None)
+            _save_current_playwright_frame(None)
             CommonUtil.ExecLog(sModuleInfo, "Switched to default content", 1)
             return "passed"
 
@@ -2120,6 +2184,7 @@ async def switch_iframe(step_data):
 
         # Store frame locator for subsequent actions
         sr.Set_Shared_Variables("playwright_frame", frame_locator)
+        _save_current_playwright_frame(frame_locator)
         CommonUtil.ExecLog(sModuleInfo, "Switched to iframe", 1)
         return "passed"
 
@@ -2134,7 +2199,7 @@ async def switch_iframe(step_data):
 #########################
 
 @logger
-def Handle_Browser_Alert(step_data):
+async def Handle_Browser_Alert(step_data):
     """
     Handle browser alerts/dialogs.
 
@@ -2189,45 +2254,30 @@ def Handle_Browser_Alert(step_data):
                 if left_l in ("timeout", "wait"):
                     timeout = int(float(right_v) * 1000)
 
-        # Set up dialog handler
-        dialog_info = {"message": None, "handled": False}
-
-        def handle_dialog(dialog):
-            dialog_info["message"] = dialog.message
-            dialog_info["type"] = dialog.type
-
-            if action in ("accept", "ok", "yes"):
-                if prompt_text:
-                    dialog.accept(prompt_text)
-                else:
-                    dialog.accept()
-            elif action in ("dismiss", "cancel", "no"):
-                dialog.dismiss()
-            else:
-                dialog.accept()
-
-            dialog_info["handled"] = True
-
-        current_page.on("dialog", handle_dialog)
-
-        # Wait for dialog
         try:
-            current_page.wait_for_event("dialog", timeout=timeout)
+            dialog = await current_page.wait_for_event("dialog", timeout=timeout)
         except PlaywrightTimeoutError:
             CommonUtil.ExecLog(sModuleInfo, "No alert appeared within timeout", 2)
-            current_page.remove_listener("dialog", handle_dialog)
             return "passed"  # Not necessarily a failure
 
-        # Remove listener
-        current_page.remove_listener("dialog", handle_dialog)
+        message = dialog.message
+        if action in ("accept", "ok", "yes"):
+            if prompt_text:
+                await dialog.accept(prompt_text)
+            else:
+                await dialog.accept()
+        elif action in ("dismiss", "cancel", "no"):
+            await dialog.dismiss()
+        else:
+            await dialog.accept()
 
         # Save text if requested
-        if save_variable and dialog_info["message"]:
-            sr.Set_Shared_Variables(save_variable, dialog_info["message"])
+        if save_variable and message:
+            sr.Set_Shared_Variables(save_variable, message)
 
         CommonUtil.ExecLog(
             sModuleInfo,
-            f"Alert handled ({action}): {dialog_info.get('message', 'N/A')}",
+            f"Alert handled ({action}): {message or 'N/A'}",
             1
         )
         return "passed"
@@ -2513,7 +2563,7 @@ async def upload_file(step_data):
 #########################
 
 @logger
-def resize_window(step_data):
+async def resize_window(step_data):
     """
     Resize the browser viewport.
 
@@ -2562,7 +2612,7 @@ def resize_window(step_data):
             width = width or current_size["width"]
             height = height or current_size["height"]
 
-        current_page.set_viewport_size({"width": width, "height": height})
+        await current_page.set_viewport_size({"width": width, "height": height})
         CommonUtil.ExecLog(sModuleInfo, f"Window resized to {width}x{height}", 1)
         return "passed"
 
@@ -2652,7 +2702,7 @@ async def Wait_For_Element(step_data):
 #########################
 
 @logger
-def Start_Tracing(step_data):
+async def Start_Tracing(step_data):
     """
     Start Playwright trace recording.
 
@@ -2687,7 +2737,7 @@ def Start_Tracing(step_data):
                 elif left_l == "sources":
                     sources = right_v in ("true", "yes", "1")
 
-        context.tracing.start(
+        await context.tracing.start(
             screenshots=screenshots,
             snapshots=snapshots,
             sources=sources
@@ -2700,7 +2750,7 @@ def Start_Tracing(step_data):
 
 
 @logger
-def Stop_Tracing(step_data):
+async def Stop_Tracing(step_data):
     """
     Stop tracing and save trace file.
 
@@ -2727,7 +2777,7 @@ def Stop_Tracing(step_data):
             if mid_l == "input parameter" and left_l == "path":
                 trace_path = right_v
 
-        context.tracing.stop(path=trace_path)
+        await context.tracing.stop(path=trace_path)
         CommonUtil.ExecLog(sModuleInfo, f"Trace saved to: {trace_path}", 1)
         return "passed"
 
@@ -2736,7 +2786,7 @@ def Stop_Tracing(step_data):
 
 
 @logger
-def Intercept_Network(step_data):
+async def Intercept_Network(step_data):
     """
     Set up network request interception.
 
@@ -2776,20 +2826,20 @@ def Intercept_Network(step_data):
             elif mid_l == "action":
                 action = right_v.lower()
 
-        def handle_route(route):
+        async def handle_route(route):
             if action == "abort":
-                route.abort()
+                await route.abort()
             elif action == "fulfill":
                 fulfill_options = {}
                 if response_body:
                     fulfill_options["body"] = response_body
                 if response_status:
                     fulfill_options["status"] = response_status
-                route.fulfill(**fulfill_options)
+                await route.fulfill(**fulfill_options)
             else:
-                route.continue_()
+                await route.continue_()
 
-        current_page.route(url_pattern, handle_route)
+        await current_page.route(url_pattern, handle_route)
         CommonUtil.ExecLog(sModuleInfo, f"Network interception set up for: {url_pattern}", 1)
         return "passed"
 

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -220,8 +220,13 @@ async def Open_Browser(step_data):
             "devtools": devtools,
         }
         
-        # Add remote debugging port for CDP connection
-        all_args = args + ["--remote-debugging-port=9222"]
+        # Add remote debugging port for CDP connection with unique port per session
+        import hashlib
+        # Generate unique port based on page_id (range 9222-9322 to avoid conflicts)
+        port_hash = int(hashlib.md5(page_id.encode()).hexdigest(), 16)
+        unique_port = 9222 + (port_hash % 100)
+        all_args = args + [f"--remote-debugging-port={unique_port}"]
+        CommonUtil.ExecLog(sModuleInfo, f"Using remote debugging port {unique_port} for session '{page_id}'", 1)
         if all_args:
             launch_options["args"] = all_args
         if downloads_path:
@@ -293,7 +298,7 @@ async def Open_Browser(step_data):
         CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
 
         # Connect Selenium to Playwright via CDP
-        selenium_driver = connect_selenium_to_playwright(port=9222)
+        selenium_driver = connect_selenium_to_playwright(port=unique_port)
 
         # Create browser session
         from Framework.Built_In_Automation.Web.utils import create_browser_session

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -77,7 +77,7 @@ def connect_selenium_to_playwright(port=9222):
         sr.Set_Shared_Variables("selenium_driver", driver)
         
         CommonUtil.ExecLog("connect_selenium_to_playwright", "Connected Selenium to Playwright", 1)
-        return "passed"
+        return driver
         
     except Exception as e:
         CommonUtil.ExecLog("connect_selenium_to_playwright", f"Failed to connect Selenium to Playwright: {e}", 3)
@@ -168,8 +168,6 @@ async def Open_Browser(step_data):
                     url = right_v
                 elif left_l in ("browser", "browser name"):
                     browser_name = right_v.lower()
-                elif left_l in ("driver id", "page id", "driver tag"):
-                    page_id = right_v
 
             elif mid_l == "optional parameter":
                 if left_l == "headless":
@@ -199,6 +197,8 @@ async def Open_Browser(step_data):
                     color_scheme = right_v
                 elif left_l == "permission":
                     permissions.append(right_v)
+                elif left_l in ("driver id", "page id", "driver tag", "session"):
+                    page_id = right_v    
 
             elif mid_l == "shared capability":
                 # Handle Selenium-style capabilities where possible
@@ -293,7 +293,20 @@ async def Open_Browser(step_data):
         CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
 
         # Connect Selenium to Playwright via CDP
-        connect_selenium_to_playwright(port=9222)
+        selenium_driver = connect_selenium_to_playwright(port=9222)
+
+        # Create browser session
+        from Framework.Built_In_Automation.Web.utils import create_browser_session
+        
+        create_browser_session(
+            session_name=page_id,
+            selenium_driver=selenium_driver,
+            playwright_page=current_page,
+            playwright_browser=browser,
+            playwright_context=context,
+            playwright_frame=None
+        )
+        CommonUtil.ExecLog(sModuleInfo, f"Created browser session: {page_id}", 5)
 
         CommonUtil.ExecLog(sModuleInfo, f"Browser opened successfully (page_id: {page_id})", 1)
         return "passed"

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -507,57 +507,136 @@ async def Tear_Down_Playwright(step_data=None):
     Example:
         Field               Sub Field           Value
         tear down           playwright action   tear down
+        
+    Example with session:
+        Field               Sub Field           Value
+        session             optional parameter  my_session
+        tear down           playwright action   tear down
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global playwright_instance, browser, context, current_page
     global playwright_details, current_page_id
 
     try:
-        # Close all tracked pages/contexts
-        for page_id, details in playwright_details.items():
+        # Parse session parameter
+        session_name = None
+        if step_data:
+            for left, mid, right in step_data:
+                left_l = left.strip().lower()
+                mid_l = mid.strip().lower()
+                right_v = right.strip()
+                
+                if mid_l == "optional parameter" and left_l == "session":
+                    session_name = right_v
+                    break
+        
+        # Handle session-specific teardown
+        if session_name:
+            from Framework.Built_In_Automation.Web.utils import get_browser_session
+            existing_session = get_browser_session(session_name)
+            
+            if existing_session and existing_session.get("playwright_page"):
+                try:
+                    # Close the specific session's page and context
+                    session_page = existing_session["playwright_page"]
+                    session_context = existing_session["playwright_context"]
+                    session_browser = existing_session["playwright_browser"]
+                    
+                    if session_page:
+                        await session_page.close()
+                    if session_context:
+                        await session_context.close()
+                    
+                    CommonUtil.ExecLog(sModuleInfo, f"Teared down session '{session_name}'", 1)
+                except Exception as e:
+                    errMsg = f"Unable to tear down session '{session_name}'. may already been killed"
+                    CommonUtil.ExecLog(sModuleInfo, errMsg, 2)
+                
+                # Remove session from browser_sessions
+                browser_sessions = sr.Get_Shared_Variables("browser_sessions", {})
+                if session_name in browser_sessions:
+                    del browser_sessions[session_name]
+                    sr.Set_Shared_Variables("browser_sessions", browser_sessions)
+                
+                # Remove from playwright_details if present
+                if session_name in playwright_details:
+                    del playwright_details[session_name]
+                
+                # If this was the current session, clear globals
+                if current_page_id == session_name:
+                    current_page = None
+                    context = None
+                    browser = None
+                    current_page_id = None
+                    
+                    # Try to switch to another available session
+                    if playwright_details:
+                        for page_id, details in playwright_details.items():
+                            current_page = details["page"]
+                            context = details["context"]
+                            browser = details["browser"]
+                            current_page_id = page_id
+                            
+                            # Update shared variables
+                            sr.Set_Shared_Variables("playwright_page", current_page)
+                            sr.Set_Shared_Variables("playwright_context", context)
+                            sr.Set_Shared_Variables("playwright_browser", browser)
+                            
+                            CommonUtil.ExecLog(sModuleInfo, f"Switched to session '{page_id}'", 1)
+                            break
+            else:
+                CommonUtil.ExecLog(sModuleInfo, f"Session '{session_name}' not found. Nothing to tear down.", 2)
+        
+        # Handle full teardown (backwards compatibility)
+        else:
+            # Close all tracked pages/contexts
+            for page_id, details in playwright_details.items():
+                try:
+                    if details.get("page"):
+                        await details["page"].close()
+                    if details.get("context"):
+                        await details["context"].close()
+                except Exception:
+                    pass
+
+        # Close main instances
             try:
-                if details.get("page"):
-                    await details["page"].close()
-                if details.get("context"):
-                    await details["context"].close()
+                if current_page and current_page not in [d.get("page") for d in playwright_details.values()]:
+                    await current_page.close()
             except Exception:
                 pass
 
-        # Close main instances
-        try:
-            if current_page and current_page not in [d.get("page") for d in playwright_details.values()]:
-                await current_page.close()
-        except Exception:
-            pass
+            try:
+                if context:
+                    await context.close()
+            except Exception:
+                pass
 
-        try:
-            if context:
-                await context.close()
-        except Exception:
-            pass
+            try:
+                if browser:
+                    await browser.close()
+            except Exception:
+                pass
 
-        try:
-            if browser:
-                await browser.close()
-        except Exception:
-            pass
+            try:
+                if playwright_instance:
+                    await playwright_instance.stop()
+            except Exception:
+                pass
 
-        try:
-            if playwright_instance:
-                await playwright_instance.stop()
-        except Exception:
-            pass
+            # Reset all globals
+            current_page = None
+            context = None
+            browser = None
+            playwright_instance = None
+            playwright_details = {}
+            current_page_id = None
+            
+            # Clear all browser sessions
+            sr.Set_Shared_Variables("browser_sessions", {})
 
-        # Reset all globals
-        current_page = None
-        context = None
-        browser = None
-        playwright_instance = None
-        playwright_details = {}
-        current_page_id = None
-
-        CommonUtil.ExecLog(sModuleInfo, "Browser closed successfully", 1)
-        return "passed"
+            CommonUtil.ExecLog(sModuleInfo, "Browser closed successfully", 1)
+            return "passed"
 
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -332,7 +332,59 @@ async def Go_To_Link(step_data):
     global current_page
 
     try:
-        if current_page is None:
+        # Parse session parameter first
+        session_name = None
+        for left, mid, right in step_data:
+            left_l = left.strip().lower()
+            mid_l = mid.strip().lower()
+            right_v = right.strip()
+            
+            if mid_l == "optional parameter" and left_l == "session":
+                session_name = right_v
+                break
+        
+        # Check if session exists and use it
+        if session_name:
+            from Framework.Built_In_Automation.Web.utils import get_browser_session
+            existing_session = get_browser_session(session_name)
+            
+            if existing_session and existing_session.get("playwright_page"):
+                # Session exists, use existing browser
+                current_page = existing_session["playwright_page"]
+                context = existing_session["playwright_context"]
+                browser = existing_session["playwright_browser"]
+                current_page_id = session_name
+                
+                # Update globals
+                globals().update({
+                    'current_page': current_page,
+                    'context': context,
+                    'browser': browser,
+                    'current_page_id': current_page_id
+                })
+                
+                # Update shared variables
+                sr.Set_Shared_Variables("playwright_page", current_page)
+                sr.Set_Shared_Variables("playwright_context", context)
+                sr.Set_Shared_Variables("playwright_browser", browser)
+                
+                CommonUtil.ExecLog(sModuleInfo, f"Using existing browser session: {session_name}", 1)
+            else:
+                # Session doesn't exist, open new browser with session name
+                CommonUtil.ExecLog(sModuleInfo, f"Session '{session_name}' not found. Opening new browser.", 2)
+                
+                # Add session parameter to step_data for Open_Browser
+                step_data_with_session = step_data.copy()
+                if not any(left.strip().lower() == "session" and mid.strip().lower() == "optional parameter" for left, mid, right in step_data_with_session):
+                    step_data_with_session.append(("session", "optional parameter", session_name))
+                
+                result = await Open_Browser(step_data_with_session)
+                if result == "zeuz_failed":
+                    CommonUtil.ExecLog(sModuleInfo, "Failed to open browser for new session", 3)
+                    return "zeuz_failed"
+        
+        elif current_page is None:
+            # No session specified and no browser open
             CommonUtil.ExecLog(sModuleInfo, "No browser open. Opening browser with default settings.", 2)
             result = await Open_Browser(step_data)
             if result == "zeuz_failed":
@@ -351,7 +403,10 @@ async def Go_To_Link(step_data):
             if left_l in ("go to link", "url", "link"):
                     url = right_v
             elif mid_l == "optional parameter":
-                if left_l in ("wait until", "wait_until", "waituntil", "wait time"):
+                if left_l == "session":
+                    # Skip session parameter - already processed above
+                    continue
+                elif left_l in ("wait until", "wait_until", "waituntil", "wait time"):
                     wait_until = right_v.lower()
                 elif left_l == "timeout":
                     timeout = int(float(right_v) * 1000)

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -112,6 +112,69 @@ default_viewport = {"width": 1920, "height": 1080}
 #                       #
 #########################
 
+def _handle_playwright_session(step_data):
+    """
+    Helper function to handle session parameter for Playwright actions.
+    
+    Args:
+        step_data: The step data containing potential session parameter
+        
+    Returns:
+        tuple: (session_name, current_page, current_page_id, context, browser)
+        - session_name: The session name found or None
+        - current_page: The appropriate page instance
+        - current_page_id: The current page ID
+        - context: The browser context
+        - browser: The browser instance
+    """
+    global current_page, current_page_id, context, browser
+    
+    # Parse session parameter
+    session_name = None
+    for left, mid, right in step_data:
+        left_l = left.strip().lower()
+        mid_l = mid.strip().lower()
+        right_v = right.strip()
+        
+        if mid_l == "optional parameter" and left_l == "session":
+            session_name = right_v
+            break
+    
+    # If session parameter is provided, switch to that session
+    if session_name:
+        from Framework.Built_In_Automation.Web.utils import get_browser_session
+        existing_session = get_browser_session(session_name)
+        
+        if existing_session and existing_session.get("playwright_page"):
+            # Session exists, use existing browser
+            current_page = existing_session["playwright_page"]
+            context = existing_session["playwright_context"]
+            browser = existing_session["playwright_browser"]
+            current_page_id = session_name
+            
+            # Update globals
+            globals().update({
+                'current_page': current_page,
+                'context': context,
+                'browser': browser,
+                'current_page_id': current_page_id
+            })
+            
+            # Update shared variables
+            sr.Set_Shared_Variables("playwright_page", current_page)
+            sr.Set_Shared_Variables("playwright_context", context)
+            sr.Set_Shared_Variables("playwright_browser", browser)
+            
+            sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+            CommonUtil.ExecLog(sModuleInfo, f"Using existing browser session: {session_name}", 1)
+        else:
+            # Session doesn't exist
+            sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+            CommonUtil.ExecLog(sModuleInfo, f"Session '{session_name}' not found. Using current browser.", 2)
+    
+    return session_name, current_page, current_page_id, context, browser
+
+
 @logger
 async def Open_Browser(step_data):
     """
@@ -590,6 +653,9 @@ async def Click_Element(step_data):
     global current_page
 
     try:
+        # Handle session parameter
+        session_name, current_page, current_page_id, context, browser = _handle_playwright_session(step_data)
+        
         if current_page is None:
             CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
             return "zeuz_failed"
@@ -608,6 +674,10 @@ async def Click_Element(step_data):
             left_l = left.strip().lower()
             mid_l = mid.strip().lower()
             right_v = right.strip()
+
+            # Skip session parameter - already handled above
+            if mid_l == "optional parameter" and left_l == "session":
+                continue
 
             if mid_l == "optional parameter":
                 if left_l == "use js":
@@ -796,6 +866,9 @@ async def Enter_Text_In_Text_Box(step_data):
     global current_page
 
     try:
+        # Handle session parameter
+        session_name, current_page, current_page_id, context, browser = _handle_playwright_session(step_data)
+        
         if current_page is None:
             CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
             return "zeuz_failed"
@@ -809,6 +882,10 @@ async def Enter_Text_In_Text_Box(step_data):
         for left, mid, right in step_data:
             left_l = left.strip().lower()
             mid_l = mid.strip().lower()
+
+            # Skip session parameter - already handled above
+            if mid_l == "optional parameter" and left_l == "session":
+                continue
 
             if mid_l == "action":
                 text_value = right  # Don't strip - preserve whitespace

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -231,6 +231,8 @@ async def Open_Browser(step_data):
                     url = right_v
                 elif left_l in ("browser", "browser name"):
                     browser_name = right_v.lower()
+                elif left_l in ("driver id", "page id", "driver tag", "session"):
+                    page_id = right_v
 
             elif mid_l == "optional parameter":
                 if left_l == "headless":

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -3502,12 +3502,62 @@ def Tear_Down_Selenium(step_data=[]):
     global current_driver_id
     try:
         driver_id = ""
+        session_name = None
+        
+        # Parse both driverid (legacy) and session (new) parameters
         for left, mid, right in step_data:
             left = left.replace(" ", "").replace("_", "").replace("-", "").lower()
             if left == "driverid":
                 driver_id = right.strip()
+            elif left == "session" and mid.strip().lower() == "optional parameter":
+                session_name = right.strip()
+                # For backward compatibility, treat session_name as driver_id
+                driver_id = session_name
 
-        if not driver_id:
+        # Handle session-specific teardown
+        if session_name:
+            from Framework.Built_In_Automation.Web.utils import get_browser_session
+            existing_session = get_browser_session(session_name)
+            
+            if existing_session and existing_session.get("selenium_driver"):
+                try:
+                    # Close the specific session's browser
+                    session_driver = existing_session["selenium_driver"]
+                    session_driver.quit()
+                    CommonUtil.ExecLog(sModuleInfo, f"Teared down session '{session_name}'", 1)
+                except Exception as e:
+                    errMsg = f"Unable to tear down session '{session_name}'. may already been killed"
+                    CommonUtil.ExecLog(sModuleInfo, errMsg, 2)
+                    CommonUtil.Exception_Handler(sys.exc_info(), None, errMsg)
+                
+                # Remove session from browser_sessions
+                browser_sessions = Shared_Resources.Get_Shared_Variables("browser_sessions", {})
+                if session_name in browser_sessions:
+                    del browser_sessions[session_name]
+                    Shared_Resources.Set_Shared_Variables("browser_sessions", browser_sessions)
+                
+                # Remove from selenium_details if present
+                if session_name in selenium_details:
+                    del selenium_details[session_name]
+                
+                # If this was the current driver, switch to another or clear
+                if current_driver_id == session_name:
+                    if selenium_details:
+                        for driver in selenium_details:
+                            selenium_driver = selenium_details[driver]["driver"]
+                            Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
+                            CommonUtil.ExecLog(sModuleInfo, f"Current driver switched to driver_id='{driver}'", 1)
+                            current_driver_id = driver
+                            break
+                    else:
+                        Shared_Resources.Remove_From_Shared_Variables("selenium_driver")
+                        selenium_driver = None
+                        current_driver_id = None
+            else:
+                CommonUtil.ExecLog(sModuleInfo, f"Session '{session_name}' not found. Nothing to tear down.", 2)
+        
+        # Handle existing driver_id logic (backwards compatibility)
+        elif not driver_id:
             CommonUtil.Join_Thread_and_Return_Result(
                 "screenshot"
             )  # Let the capturing screenshot end in thread
@@ -3525,6 +3575,8 @@ def Tear_Down_Selenium(step_data=[]):
                     CommonUtil.ExecLog(sModuleInfo, errMsg, 2)
                     CommonUtil.Exception_Handler(sys.exc_info(), None, errMsg)
             Shared_Resources.Remove_From_Shared_Variables("selenium_driver")
+            # Clear all browser sessions
+            Shared_Resources.Set_Shared_Variables("browser_sessions", {})
             selenium_details = {}
             selenium_driver = None
 

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -777,27 +777,30 @@ async def Open_Browser(browser, browser_options: BrowserOptions, session_name: s
             )
             return "zeuz_failed"
 
-        # Connect Playwright to Selenium via CDP
-        playwright_browser = None
-        playwright_context = None
-        playwright_page = None
-        try:
-            playwright_browser, playwright_context, playwright_page = await connect_playwright_to_selenium(port=9222)
-            CommonUtil.ExecLog(sModuleInfo, "Connected Playwright to Selenium", 1)
-        except Exception as e:
-            CommonUtil.ExecLog(sModuleInfo, f"Failed to connect Playwright to Selenium: {e}", 3)
+        # If selenium_driver is of type Webdriver
+        from selenium.webdriver import Chrome, Firefox, Edge, Safari
+        if isinstance(selenium_driver, (Chrome, Firefox, Edge, Safari)):
+            # Connect Playwright to Selenium via CDP
+            playwright_browser = None
+            playwright_context = None
+            playwright_page = None
+            try:
+                playwright_browser, playwright_context, playwright_page = await connect_playwright_to_selenium(port=9222)
+                CommonUtil.ExecLog(sModuleInfo, "Connected Playwright to Selenium", 1)
+            except Exception as e:
+                CommonUtil.ExecLog(sModuleInfo, f"Failed to connect Playwright to Selenium: {e}", 3)
 
-        # Create browser session
-        from Framework.Built_In_Automation.Web.utils import create_browser_session
-        session = create_browser_session(
-            session_name=session_name,
-            selenium_driver=selenium_driver,
-            playwright_page=playwright_page,
-            playwright_browser=playwright_browser,
-            playwright_context=playwright_context,
-            playwright_frame=None
-        )
-        CommonUtil.ExecLog(sModuleInfo, f"Created browser session: {session_name=}", 5)
+            # Create browser session
+            from Framework.Built_In_Automation.Web.utils import create_browser_session
+            session = create_browser_session(
+                session_name=session_name,
+                selenium_driver=selenium_driver,
+                playwright_page=playwright_page,
+                playwright_browser=playwright_browser,
+                playwright_context=playwright_context,
+                playwright_frame=None
+            )
+            CommonUtil.ExecLog(sModuleInfo, f"Created browser session: {session_name=}", 5)
 
         CommonUtil.ExecLog(sModuleInfo, f"Started {browser} browser", 1)
         Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -150,6 +150,50 @@ Dataset = list[tuple[str, str, str]]
 ReturnType = Literal["passed", "zeuz_failed"]
 
 
+def _handle_selenium_session(step_data):
+    """
+    Helper function to handle session parameter for Selenium actions.
+    
+    Args:
+        step_data: The step data containing potential session parameter
+        
+    Returns:
+        tuple: (session_name, selenium_driver, current_driver_id)
+        - session_name: The session name found or None
+        - selenium_driver: The appropriate selenium driver instance
+        - current_driver_id: The current driver ID
+    """
+    global selenium_driver, current_driver_id
+    
+    # Parse session parameter
+    session_name = None
+    for left, mid, right in step_data:
+        left = left.replace(" ", "").replace("_", "").replace("-", "").lower()
+        if left == "session" and mid.strip().lower() == "optional parameter":
+            session_name = right.strip()
+            break
+    
+    # If session parameter is provided, switch to that session
+    if session_name:
+        from Framework.Built_In_Automation.Web.utils import get_browser_session
+        existing_session = get_browser_session(session_name)
+        
+        if existing_session and existing_session.get("selenium_driver"):
+            # Session exists, use existing driver
+            selenium_driver = existing_session["selenium_driver"]
+            current_driver_id = session_name
+            Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
+            
+            sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+            CommonUtil.ExecLog(sModuleInfo, f"Using existing browser session: {session_name}", 1)
+        else:
+            # Session doesn't exist
+            sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+            CommonUtil.ExecLog(sModuleInfo, f"Session '{session_name}' not found. Using current browser.", 2)
+    
+    return session_name, selenium_driver, current_driver_id
+
+
 class DefaultChromiumArguments(TypedDict):
     add_argument: list[str]
     add_experimental_option: dict[str, Any]
@@ -1645,6 +1689,10 @@ def Enter_Text_In_Text_Box(step_data):
         use_js = False
         clear = True
         global selenium_driver
+        
+        # Handle session parameter
+        session_name, selenium_driver, current_driver_id = _handle_selenium_session(step_data)
+        
         Element = LocateElement.Get_Element(step_data, selenium_driver)
         if Element == "zeuz_failed":
             CommonUtil.ExecLog(
@@ -1654,6 +1702,9 @@ def Enter_Text_In_Text_Box(step_data):
         for left, mid, right in step_data:
             mid = mid.strip().lower()
             left = left.strip().lower()
+            # Skip session parameter - already handled above
+            if left == "session" and mid == "optional parameter":
+                continue
             if mid == "action":
                 text_value = right
             elif left == "delay":
@@ -2088,8 +2139,14 @@ def Click_Element(data_set, retry=0):
     global selenium_driver
     use_js = False  # Use js to click on element?
     try:
+        # Handle session parameter
+        session_name, selenium_driver, current_driver_id = _handle_selenium_session(data_set)
+        
         location = ""
         for row in data_set:
+            # Skip session parameter - already handled above
+            if row[0].lower().replace(" ", "").replace("_", "").replace("-", "") == "session" and row[1].strip().lower() == "optional parameter":
+                continue
             if row[0] == "offset" and row[1] == "optional parameter":
                 location = row[
                     2
@@ -3035,6 +3092,9 @@ def Validate_Text(step_data):
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global selenium_driver
     try:
+        # Handle session parameter
+        session_name, selenium_driver, current_driver_id = _handle_selenium_session(step_data)
+        
         Element = LocateElement.Get_Element(step_data, selenium_driver)
         ignore_case = False
         zeuz_ai = None
@@ -3044,6 +3104,9 @@ def Validate_Text(step_data):
             )
             return "zeuz_failed"
         for each_step_data_item in step_data:
+            # Skip session parameter - already handled above
+            if each_step_data_item[0].lower().replace(" ", "").replace("_", "").replace("-", "") == "session" and each_step_data_item[1].strip().lower() == "optional parameter":
+                continue
             if each_step_data_item[1] == "action":
                 expected_text_data = each_step_data_item[2]
                 validation_type = each_step_data_item[0]
@@ -3149,6 +3212,9 @@ def Scroll(step_data):
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global selenium_driver
     try:
+        # Handle session parameter
+        session_name, selenium_driver, current_driver_id = _handle_selenium_session(step_data)
+        
         Element = None
         get_element = False
         scroll_direction = ""
@@ -3156,6 +3222,10 @@ def Scroll(step_data):
         pixel = 750
         for left, mid, right in step_data:
             mid = mid.strip().lower()
+            left_clean = left.replace(" ", "").replace("_", "").replace("-", "").lower()
+            # Skip session parameter - already handled above
+            if left_clean == "session" and mid == "optional parameter":
+                continue
             if "action" in mid:
                 scroll_direction = right.strip().lower()
             elif mid == "element parameter":

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -671,11 +671,11 @@ async def connect_playwright_to_selenium(port=9222):
     Shared_Resources.Set_Shared_Variables("playwright_browser", browser)
     Shared_Resources.Set_Shared_Variables("playwright_page", page)
 
-    return "passed"
+    return browser, context, page
 
 
 @logger
-async def Open_Browser(browser, browser_options: BrowserOptions):
+async def Open_Browser(browser, browser_options: BrowserOptions, session_name: str = "default"):
     """Launch browser from options and service object"""
     try:
         global selenium_driver
@@ -778,11 +778,26 @@ async def Open_Browser(browser, browser_options: BrowserOptions):
             return "zeuz_failed"
 
         # Connect Playwright to Selenium via CDP
+        playwright_browser = None
+        playwright_context = None
+        playwright_page = None
         try:
-            await connect_playwright_to_selenium(port=9222)
+            playwright_browser, playwright_context, playwright_page = await connect_playwright_to_selenium(port=9222)
             CommonUtil.ExecLog(sModuleInfo, "Connected Playwright to Selenium", 1)
         except Exception as e:
             CommonUtil.ExecLog(sModuleInfo, f"Failed to connect Playwright to Selenium: {e}", 3)
+
+        # Create browser session
+        from Framework.Built_In_Automation.Web.utils import create_browser_session
+        session = create_browser_session(
+            session_name=session_name,
+            selenium_driver=selenium_driver,
+            playwright_page=playwright_page,
+            playwright_browser=playwright_browser,
+            playwright_context=playwright_context,
+            playwright_frame=None
+        )
+        CommonUtil.ExecLog(sModuleInfo, f"Created browser session: {session_name=}", 5)
 
         CommonUtil.ExecLog(sModuleInfo, f"Started {browser} browser", 1)
         Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
@@ -1018,6 +1033,7 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
         chrome_version = None
         chrome_channel = None
         debug_port = False
+        session_name = "default"
 
         for left, mid, right in dataset:
             left = left.replace(" ", "").replace("_", "").replace("-", "").lower()
@@ -1037,6 +1053,8 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
                 window_size_Y = int(resolution[1])
             elif left == "chrome:version":
                 chrome_version = right.strip()
+            elif left == "session":
+                session_name = right.strip()
 
             # Capabilities are WebDriver attribute common across different browser
             elif mid.strip().lower() == "shared capability":
@@ -1145,7 +1163,7 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
                 sModuleInfo, "Browser not previously opened, doing so now", 1
             )
 
-            if await Open_Browser(dependency["Browser"], browser_options) == "zeuz_failed":
+            if await Open_Browser(dependency["Browser"], browser_options, session_name) == "zeuz_failed":
                 return "zeuz_failed"
 
             if ConfigModule.get_config_value(
@@ -1219,7 +1237,7 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
             # If the browser is closed but selenium instance is on, relaunch selenium_driver
             if Shared_Resources.Test_Shared_Variables("dependency"):
                 dependency = Shared_Resources.Get_Shared_Variables("dependency")
-            result = await Open_Browser(dependency["Browser"], browser_options)
+            result = await Open_Browser(dependency["Browser"], browser_options, session_name)
         else:
             result = "zeuz_failed"
 

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -1245,6 +1245,11 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
             else:
                 selenium_driver.set_window_size(window_size_X, window_size_Y)
 
+            if debug_port is None:
+                import hashlib
+                port_hash = int(hashlib.md5(session_name.encode()).hexdigest(), 16)
+                debug_port = 9222 + (port_hash % 100)
+
             selenium_details[driver_id] = {
                 "driver": Shared_Resources.Get_Shared_Variables("selenium_driver"),
                 "remote-debugging-port": debug_port
@@ -4765,7 +4770,7 @@ def playwright(dataset):
         # Get the correct remote debugging port for current driver
         debug_port = 9222  # fallback
         if current_driver_id and current_driver_id in selenium_details:
-            debug_port = selenium_details[current_driver_id].get("remote-debugging-port", 9222)
+            debug_port = selenium_details[current_driver_id].get("remote-debugging-port") or 9222
 
         devtools_url = (
             selenium_driver.command_executor._url.replace("http://", "ws://")

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -72,7 +72,14 @@ from Framework.AI.NLP import binary_classification
 from .utils import ChromeForTesting, ChromeExtensionDownloader
 
 from playwright.async_api import async_playwright
-from Framework.Built_In_Automation.Web.utils import get_browser_session, create_browser_session
+from Framework.Built_In_Automation.Web.utils import (
+    create_browser_session,
+    extract_session_name,
+    get_browser_session,
+    get_browser_sessions,
+    get_debug_port,
+    remove_browser_session,
+)
 
 #########################
 #                       #
@@ -165,17 +172,10 @@ def _handle_selenium_session(step_data):
     """
     global selenium_driver, current_driver_id
     
-    # Parse session parameter
-    session_name = None
-    for left, mid, right in step_data:
-        left = left.replace(" ", "").replace("_", "").replace("-", "").lower()
-        if left == "session" and mid.strip().lower() == "optional parameter":
-            session_name = right.strip()
-            break
+    session_name = extract_session_name(step_data)
     
     # If session parameter is provided, switch to that session
     if session_name:
-        from Framework.Built_In_Automation.Web.utils import get_browser_session
         existing_session = get_browser_session(session_name)
         
         if existing_session and existing_session.get("selenium_driver"):
@@ -183,15 +183,89 @@ def _handle_selenium_session(step_data):
             selenium_driver = existing_session["selenium_driver"]
             current_driver_id = session_name
             Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
+            Shared_Resources.Set_Shared_Variables("active_web_driver_type", "selenium")
             
             sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
             CommonUtil.ExecLog(sModuleInfo, f"Using existing browser session: {session_name}", 1)
         else:
-            # Session doesn't exist
             sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
-            CommonUtil.ExecLog(sModuleInfo, f"Session '{session_name}' not found. Using current browser.", 2)
+            CommonUtil.ExecLog(sModuleInfo, f"Browser session '{session_name}' not found", 3)
+            raise ValueError(f"Browser session '{session_name}' not found")
     
     return session_name, selenium_driver, current_driver_id
+
+
+def _activate_browser_session_for_action(step_data, function_name=None):
+    """Select the requested browser session before running Selenium actions."""
+
+    global selenium_driver, current_driver_id, selenium_details
+
+    session_name = extract_session_name(step_data)
+    if not session_name:
+        return "passed"
+
+    create_or_cleanup_actions = {
+        "Go_To_Link",
+        "Go_To_Link_V2",
+        "Open_Electron_App",
+        "Tear_Down_Selenium",
+    }
+    if function_name in create_or_cleanup_actions:
+        return "passed"
+
+    existing_session = get_browser_session(session_name)
+    if not existing_session or not existing_session.get("selenium_driver"):
+        sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+        CommonUtil.ExecLog(sModuleInfo, f"Browser session '{session_name}' not found", 3)
+        return "zeuz_failed"
+
+    selenium_driver = existing_session["selenium_driver"]
+    current_driver_id = session_name
+    selenium_details.setdefault(session_name, {})["driver"] = selenium_driver
+    if existing_session.get("remote_debugging_port"):
+        selenium_details[session_name]["remote-debugging-port"] = existing_session["remote_debugging_port"]
+    Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
+    Shared_Resources.Set_Shared_Variables("active_web_driver_type", "selenium")
+    if existing_session.get("playwright_page"):
+        Shared_Resources.Set_Shared_Variables("playwright_page", existing_session["playwright_page"])
+    CommonUtil.set_screenshot_vars(Shared_Resources.Shared_Variable_Export())
+    return "passed"
+
+
+def _run_async_from_sync(awaitable):
+    """Run an awaitable from Selenium's sync actions, including inside an event loop."""
+
+    import asyncio
+    from concurrent.futures import ThreadPoolExecutor
+
+    try:
+        loop = asyncio.get_running_loop()
+        if loop.is_running():
+            def run_in_thread():
+                new_loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(new_loop)
+                try:
+                    return new_loop.run_until_complete(awaitable)
+                finally:
+                    new_loop.close()
+
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                return executor.submit(run_in_thread).result(timeout=30)
+    except RuntimeError:
+        pass
+
+    return asyncio.run(awaitable)
+
+
+def _close_maybe_async(resource, method_name="close"):
+    if not resource:
+        return
+    method = getattr(resource, method_name, None)
+    if not method:
+        return
+    result = method()
+    if inspect.iscoroutine(result):
+        _run_async_from_sync(result)
 
 
 class DefaultChromiumArguments(TypedDict):
@@ -473,7 +547,7 @@ def Open_Electron_App(data_set):
         desktop_app_path = ""
         driver_id = ""
         chrome_version = ""
-        for left, _, right in data_set:
+        for left, mid, right in data_set:
             left = left.replace(" ", "").replace("_", "").replace("-", "").lower()
             if "windows" in left and platform.system() == "Windows":
                 desktop_app_path = right.strip()
@@ -482,6 +556,8 @@ def Open_Electron_App(data_set):
             elif "linux" in left and platform.system() == "Linux":
                 desktop_app_path = right.strip()
             elif left == "driverid":
+                driver_id = right.strip()
+            elif left == "session" and mid.strip().lower() == "optional parameter":
                 driver_id = right.strip()
             elif left == "chrome:version":
                 chrome_version = right.strip()
@@ -511,10 +587,7 @@ def Open_Electron_App(data_set):
 
             opts = Options()
             opts.binary_location = desktop_app_path
-            # Generate unique port for Electron app based on driver_id
-            import hashlib
-            port_hash = int(hashlib.md5((driver_id or "electron").encode()).hexdigest(), 16)
-            electron_port = 9230 + (port_hash % 90)  # Range 9230-9320 to avoid conflicts with browser sessions
+            electron_port = get_debug_port(driver_id or "electron", start=9230, stop=9320)
             opts.add_argument(f"--remote-debugging-port={electron_port}")
             CommonUtil.ExecLog(sModuleInfo, f"Using remote debugging port {electron_port} for Electron app", 1)
             # service = Service(executable_path=electron_chrome_path)
@@ -533,15 +606,21 @@ def Open_Electron_App(data_set):
             selenium_driver.implicitly_wait(0.5)
             CommonUtil.ExecLog(sModuleInfo, "Started Electron App", 1)
             Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
+            Shared_Resources.Set_Shared_Variables("active_web_driver_type", "selenium")
             CommonUtil.set_screenshot_vars(Shared_Resources.Shared_Variable_Export())
 
         except Exception:
             return CommonUtil.Exception_Handler(sys.exc_info())
 
-        if driver_id in selenium_details:
-            pass  # we need to decide later based on the situation
-        else:
-            selenium_details[driver_id] = {"driver": selenium_driver}
+        selenium_details[driver_id] = {
+            "driver": selenium_driver,
+            "remote-debugging-port": electron_port,
+        }
+        create_browser_session(
+            session_name=driver_id,
+            selenium_driver=selenium_driver,
+            remote_debugging_port=electron_port,
+        )
         current_driver_id = driver_id
         return "passed"
     except:
@@ -721,7 +800,7 @@ async def connect_playwright_to_selenium(port=9222):
     Shared_Resources.Set_Shared_Variables("playwright_browser", browser)
     Shared_Resources.Set_Shared_Variables("playwright_page", page)
 
-    return browser, context, page
+    return playwright_instance, browser, context, page
 
 
 @logger
@@ -755,11 +834,8 @@ async def Open_Browser(browser, browser_options: BrowserOptions, session_name: s
 
         options = generate_options(browser, browser_options)
 
-        # Enable remote debugging / CDP with unique port per session
-        import hashlib
-        # Generate unique port based on session name (range 9222-9322 to avoid conflicts)
-        port_hash = int(hashlib.md5(session_name.encode()).hexdigest(), 16)
-        unique_port = 9222 + (port_hash % 100)
+        # Enable remote debugging / CDP with a unique port per session.
+        unique_port = get_debug_port(session_name)
         options.add_argument(f"--remote-debugging-port={unique_port}")
         CommonUtil.ExecLog(sModuleInfo, f"Using remote debugging port {unique_port} for session '{session_name}'", 1)
 
@@ -836,11 +912,12 @@ async def Open_Browser(browser, browser_options: BrowserOptions, session_name: s
         from selenium.webdriver import Chrome, Firefox, Edge, Safari
         if isinstance(selenium_driver, (Chrome, Firefox, Edge, Safari)):
             # Connect Playwright to Selenium via CDP
+            playwright_instance = None
             playwright_browser = None
             playwright_context = None
             playwright_page = None
             try:
-                playwright_browser, playwright_context, playwright_page = await connect_playwright_to_selenium(port=unique_port)
+                playwright_instance, playwright_browser, playwright_context, playwright_page = await connect_playwright_to_selenium(port=unique_port)
                 CommonUtil.ExecLog(sModuleInfo, "Connected Playwright to Selenium", 1)
             except Exception as e:
                 CommonUtil.ExecLog(sModuleInfo, f"Failed to connect Playwright to Selenium: {e}", 3)
@@ -852,12 +929,15 @@ async def Open_Browser(browser, browser_options: BrowserOptions, session_name: s
                 playwright_page=playwright_page,
                 playwright_browser=playwright_browser,
                 playwright_context=playwright_context,
-                playwright_frame=None
+                playwright_frame=None,
+                playwright_instance=playwright_instance,
+                remote_debugging_port=unique_port,
             )
             CommonUtil.ExecLog(sModuleInfo, f"Created browser session: {session_name=}", 5)
 
         CommonUtil.ExecLog(sModuleInfo, f"Started {browser} browser", 1)
         Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
+        Shared_Resources.Set_Shared_Variables("active_web_driver_type", "selenium")
         CommonUtil.set_screenshot_vars(Shared_Resources.Shared_Variable_Export())
         return "passed"
 
@@ -882,7 +962,7 @@ def Go_To_Link_V2(step_data):
     options = Options()
     page_load_strategy = "normal"
 
-    for left, _, right in step_data:
+    for left, mid, right in step_data:
         left = left.strip().lower()
         if "add argument" == left:
             options.add_argument(right.strip())
@@ -909,6 +989,8 @@ def Go_To_Link_V2(step_data):
             url = right.strip() if right.strip() != "" else None
         elif "driver tag" == left:
             driver_tag = right.strip()
+        elif left == "session" and mid.strip().lower() == "optional parameter":
+            driver_tag = right.strip()
         elif "wait for element" == left:
             Shared_Resources.Set_Shared_Variables("element_wait", float(right.strip()))
         elif "page load timeout" == left:
@@ -917,7 +999,13 @@ def Go_To_Link_V2(step_data):
             page_load_strategy = right.strip()
             options.page_load_strategy = page_load_strategy
 
-    if driver_tag in selenium_details.keys():
+    existing_session = get_browser_session(driver_tag)
+    if existing_session and existing_session.get("selenium_driver"):
+        selenium_driver = existing_session["selenium_driver"]
+        selenium_details.setdefault(driver_tag, {})["driver"] = selenium_driver
+        if existing_session.get("remote_debugging_port"):
+            selenium_details[driver_tag]["remote-debugging-port"] = existing_session["remote_debugging_port"]
+    elif driver_tag in selenium_details.keys():
         selenium_driver = selenium_details[driver_tag]["driver"]
     else:
         if Shared_Resources.Test_Shared_Variables("dependency"):
@@ -930,16 +1018,28 @@ def Go_To_Link_V2(step_data):
             options.add_argument("--headless")
             CommonUtil.ExecLog(sModuleInfo, "Added headless argument", 1)
 
+        debug_port = get_debug_port(driver_tag)
+        options.add_argument(f"--remote-debugging-port={debug_port}")
+        CommonUtil.ExecLog(sModuleInfo, f"Using remote debugging port {debug_port} for session '{driver_tag}'", 1)
+
         if "chrome" in dependency_browser:
             selenium_driver = webdriver.Chrome(options=options)
         elif "firefox" in dependency_browser:
             selenium_driver = webdriver.Firefox(options=options)
 
         selenium_driver.set_page_load_timeout(page_load_timeout_sec)
-        selenium_details[driver_tag] = dict()
-        selenium_details[driver_tag]["driver"] = selenium_driver
-        current_driver_id = selenium_driver
+        selenium_details[driver_tag] = {
+            "driver": selenium_driver,
+            "remote-debugging-port": debug_port,
+        }
+        create_browser_session(
+            session_name=driver_tag,
+            selenium_driver=selenium_driver,
+            remote_debugging_port=debug_port,
+        )
+        current_driver_id = driver_tag
         Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
+        Shared_Resources.Set_Shared_Variables("active_web_driver_type", "selenium")
 
         # Handle headless mode window maximize
         if (
@@ -953,6 +1053,8 @@ def Go_To_Link_V2(step_data):
 
     selenium_driver.maximize_window()
     Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
+    current_driver_id = driver_tag
+    Shared_Resources.Set_Shared_Variables("active_web_driver_type", "selenium")
     CommonUtil.set_screenshot_vars(Shared_Resources.Shared_Variable_Export())
     return "passed"
 
@@ -1224,7 +1326,8 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
             if await Open_Browser(dependency["Browser"], browser_options, session_name) == "zeuz_failed":
                 return "zeuz_failed"
 
-            selenium_driver = get_browser_session(session_name)["selenium_driver"]
+            session_data = get_browser_session(session_name)
+            selenium_driver = session_data.get("selenium_driver", Shared_Resources.Get_Shared_Variables("selenium_driver"))
 
             if ConfigModule.get_config_value(
                 "RunDefinition", "window_size_x"
@@ -1246,17 +1349,17 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
                 selenium_driver.set_window_size(window_size_X, window_size_Y)
 
             if debug_port is None:
-                import hashlib
-                port_hash = int(hashlib.md5(session_name.encode()).hexdigest(), 16)
-                debug_port = 9222 + (port_hash % 100)
+                debug_port = session_data.get("remote_debugging_port") or get_debug_port(session_name)
 
             selenium_details[driver_id] = {
                 "driver": Shared_Resources.Get_Shared_Variables("selenium_driver"),
                 "remote-debugging-port": debug_port
             }
         else:
-            selenium_driver = get_browser_session(session_name)["selenium_driver"]
+            session_data = get_browser_session(session_name)
+            selenium_driver = session_data.get("selenium_driver") or selenium_details[driver_id]["driver"]
             Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
+            Shared_Resources.Set_Shared_Variables("active_web_driver_type", "selenium")
         current_driver_id = driver_id
     except Exception:
         ErrorMessage = "failed to open browser"
@@ -3513,20 +3616,24 @@ def Tear_Down_Selenium(step_data=[]):
         # Parse both driverid (legacy) and session (new) parameters
         for left, mid, right in step_data:
             left = left.replace(" ", "").replace("_", "").replace("-", "").lower()
-            if left == "driverid":
-                driver_id = right.strip()
-            elif left == "session" and mid.strip().lower() == "optional parameter":
+            if left == "session" and mid.strip().lower() == "optional parameter":
                 session_name = right.strip()
-                # For backward compatibility, treat session_name as driver_id
                 driver_id = session_name
+            elif left == "driverid":
+                driver_id = right.strip()
 
         # Handle session-specific teardown
         if session_name:
-            from Framework.Built_In_Automation.Web.utils import get_browser_session
             existing_session = get_browser_session(session_name)
             
             if existing_session and existing_session.get("selenium_driver"):
                 try:
+                    try:
+                        _close_maybe_async(existing_session.get("playwright_context"))
+                        _close_maybe_async(existing_session.get("playwright_browser"))
+                        _close_maybe_async(existing_session.get("playwright_instance"), "stop")
+                    except Exception:
+                        pass
                     # Close the specific session's browser
                     session_driver = existing_session["selenium_driver"]
                     session_driver.quit()
@@ -3536,11 +3643,7 @@ def Tear_Down_Selenium(step_data=[]):
                     CommonUtil.ExecLog(sModuleInfo, errMsg, 2)
                     CommonUtil.Exception_Handler(sys.exc_info(), None, errMsg)
                 
-                # Remove session from browser_sessions
-                browser_sessions = Shared_Resources.Get_Shared_Variables("browser_sessions", {})
-                if session_name in browser_sessions:
-                    del browser_sessions[session_name]
-                    Shared_Resources.Set_Shared_Variables("browser_sessions", browser_sessions)
+                remove_browser_session(session_name)
                 
                 # Remove from selenium_details if present
                 if session_name in selenium_details:
@@ -3567,6 +3670,15 @@ def Tear_Down_Selenium(step_data=[]):
             CommonUtil.Join_Thread_and_Return_Result(
                 "screenshot"
             )  # Let the capturing screenshot end in thread
+            for session in get_browser_sessions().values():
+                if not (isinstance(session, dict) and session.get("selenium_driver")):
+                    continue
+                try:
+                    _close_maybe_async(session.get("playwright_context"))
+                    _close_maybe_async(session.get("playwright_browser"))
+                    _close_maybe_async(session.get("playwright_instance"), "stop")
+                except Exception:
+                    pass
             for driver in selenium_details:
                 try:
                     selenium_details[driver]["driver"].quit()
@@ -3581,10 +3693,16 @@ def Tear_Down_Selenium(step_data=[]):
                     CommonUtil.ExecLog(sModuleInfo, errMsg, 2)
                     CommonUtil.Exception_Handler(sys.exc_info(), None, errMsg)
             Shared_Resources.Remove_From_Shared_Variables("selenium_driver")
-            # Clear all browser sessions
-            Shared_Resources.Set_Shared_Variables("browser_sessions", {})
+            sessions = get_browser_sessions()
+            sessions = {
+                name: session
+                for name, session in sessions.items()
+                if not (isinstance(session, dict) and session.get("selenium_driver"))
+            }
+            Shared_Resources.Set_Shared_Variables("browser_sessions", sessions)
             selenium_details = {}
             selenium_driver = None
+            current_driver_id = None
 
         elif driver_id not in selenium_details:
             CommonUtil.ExecLog(
@@ -3607,6 +3725,7 @@ def Tear_Down_Selenium(step_data=[]):
                     2,
                 )
             del selenium_details[driver_id]
+            remove_browser_session(driver_id)
             if selenium_details:
                 for driver in selenium_details:
                     selenium_driver = selenium_details[driver]["driver"]
@@ -3648,13 +3767,19 @@ def Switch_Browser(step_data):
         driver_id = ""
         for left, mid, right in step_data:
             left = left.replace(" ", "").replace("_", "").replace("-", "").lower()
-            if left == "driverid":
+            if left in ("driverid", "session"):
                 driver_id = right.strip()
 
         if not driver_id:
             driver_id = "default"
 
-        if driver_id not in selenium_details:
+        existing_session = get_browser_session(driver_id)
+        if existing_session and existing_session.get("selenium_driver"):
+            selenium_driver = existing_session["selenium_driver"]
+            selenium_details.setdefault(driver_id, {})["driver"] = selenium_driver
+            if existing_session.get("remote_debugging_port"):
+                selenium_details[driver_id]["remote-debugging-port"] = existing_session["remote_debugging_port"]
+        elif driver_id not in selenium_details:
             CommonUtil.ExecLog(
                 sModuleInfo,
                 "Driver_id='%s' not found. So could not Switch" % driver_id,
@@ -3663,11 +3788,13 @@ def Switch_Browser(step_data):
             return "zeuz_failed"
         else:
             selenium_driver = selenium_details[driver_id]["driver"]
-            Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
-            current_driver_id = driver_id
-            CommonUtil.ExecLog(
-                sModuleInfo, "Current driver is set to driver_id='%s'" % driver_id, 1
-            )
+        Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
+        current_driver_id = driver_id
+        Shared_Resources.Set_Shared_Variables("active_web_driver_type", "selenium")
+        CommonUtil.set_screenshot_vars(Shared_Resources.Shared_Variable_Export())
+        CommonUtil.ExecLog(
+            sModuleInfo, "Current driver is set to driver_id='%s'" % driver_id, 1
+        )
 
         return "passed"
     except Exception:

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -72,6 +72,7 @@ from Framework.AI.NLP import binary_classification
 from .utils import ChromeForTesting, ChromeExtensionDownloader
 
 from playwright.async_api import async_playwright
+from Framework.Built_In_Automation.Web.utils import get_browser_session, create_browser_session
 
 #########################
 #                       #
@@ -466,7 +467,12 @@ def Open_Electron_App(data_set):
 
             opts = Options()
             opts.binary_location = desktop_app_path
-            opts.add_argument("--remote-debugging-port=9222")
+            # Generate unique port for Electron app based on driver_id
+            import hashlib
+            port_hash = int(hashlib.md5((driver_id or "electron").encode()).hexdigest(), 16)
+            electron_port = 9230 + (port_hash % 90)  # Range 9230-9320 to avoid conflicts with browser sessions
+            opts.add_argument(f"--remote-debugging-port={electron_port}")
+            CommonUtil.ExecLog(sModuleInfo, f"Using remote debugging port {electron_port} for Electron app", 1)
             # service = Service(executable_path=electron_chrome_path)
             arch = platform.machine().lower()
             if platform.system() == "Darwin" and arch == "arm64":
@@ -705,8 +711,13 @@ async def Open_Browser(browser, browser_options: BrowserOptions, session_name: s
 
         options = generate_options(browser, browser_options)
 
-        # Enable remote debugging / CDP
-        options.add_argument("--remote-debugging-port=9222")
+        # Enable remote debugging / CDP with unique port per session
+        import hashlib
+        # Generate unique port based on session name (range 9222-9322 to avoid conflicts)
+        port_hash = int(hashlib.md5(session_name.encode()).hexdigest(), 16)
+        unique_port = 9222 + (port_hash % 100)
+        options.add_argument(f"--remote-debugging-port={unique_port}")
+        CommonUtil.ExecLog(sModuleInfo, f"Using remote debugging port {unique_port} for session '{session_name}'", 1)
 
         if browser in ("android", "chrome", "chromeheadless"):
             from selenium.webdriver.chrome.service import Service
@@ -785,13 +796,12 @@ async def Open_Browser(browser, browser_options: BrowserOptions, session_name: s
             playwright_context = None
             playwright_page = None
             try:
-                playwright_browser, playwright_context, playwright_page = await connect_playwright_to_selenium(port=9222)
+                playwright_browser, playwright_context, playwright_page = await connect_playwright_to_selenium(port=unique_port)
                 CommonUtil.ExecLog(sModuleInfo, "Connected Playwright to Selenium", 1)
             except Exception as e:
                 CommonUtil.ExecLog(sModuleInfo, f"Failed to connect Playwright to Selenium: {e}", 3)
 
             # Create browser session
-            from Framework.Built_In_Automation.Web.utils import create_browser_session
             create_browser_session(
                 session_name=session_name,
                 selenium_driver=selenium_driver,
@@ -1043,7 +1053,7 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
             if left == "gotolink":
                 web_link = right.strip()
             elif left == "driverid":
-                driver_id = right.strip()
+                session_name = driver_id = right.strip()
             elif left in ("waittimetoappearelement", "waitforelement"):
                 Shared_Resources.Set_Shared_Variables(
                     "element_wait", float(right.strip())
@@ -1057,7 +1067,7 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
             elif left == "chrome:version":
                 chrome_version = right.strip()
             elif left == "session":
-                session_name = right.strip()
+                session_name = driver_id = right.strip()
 
             # Capabilities are WebDriver attribute common across different browser
             elif mid.strip().lower() == "shared capability":
@@ -1169,6 +1179,8 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
             if await Open_Browser(dependency["Browser"], browser_options, session_name) == "zeuz_failed":
                 return "zeuz_failed"
 
+            selenium_driver = get_browser_session(session_name)["selenium_driver"]
+
             if ConfigModule.get_config_value(
                 "RunDefinition", "window_size_x"
             ) and ConfigModule.get_config_value("RunDefinition", "window_size_y"):
@@ -1193,7 +1205,7 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
                 "remote-debugging-port": debug_port
             }
         else:
-            selenium_driver = selenium_details[driver_id]["driver"]
+            selenium_driver = get_browser_session(session_name)["selenium_driver"]
             Shared_Resources.Set_Shared_Variables("selenium_driver", selenium_driver)
         current_driver_id = driver_id
     except Exception:
@@ -4622,8 +4634,15 @@ def drag_and_drop(dataset):
 def playwright(dataset):
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global selenium_driver
+    global selenium_details
+    global current_driver_id
     try:
         from playwright.sync_api import sync_playwright
+
+        # Get the correct remote debugging port for current driver
+        debug_port = 9222  # fallback
+        if current_driver_id and current_driver_id in selenium_details:
+            debug_port = selenium_details[current_driver_id].get("remote-debugging-port", 9222)
 
         devtools_url = (
             selenium_driver.command_executor._url.replace("http://", "ws://")
@@ -4631,7 +4650,7 @@ def playwright(dataset):
         )
         with sync_playwright() as p:
             # browser = p.chromium.connect(browserURL=devtools_url)
-            browser = p.chromium.connect_over_cdp("http://localhost:9222")
+            browser = p.chromium.connect_over_cdp(f"http://localhost:{debug_port}")
             page = browser.contexts[0].pages[0]
 
             # source = page.locator("//div[contains(text(), 'abcd')]")

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -1198,6 +1198,7 @@ async def Go_To_Link(dataset: Dataset) -> ReturnType:
                 driver_id = current_driver_id
             else:
                 driver_id = list(selenium_details.keys())[0]
+            session_name = driver_id
 
         if (
             driver_id not in selenium_details

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -792,7 +792,7 @@ async def Open_Browser(browser, browser_options: BrowserOptions, session_name: s
 
             # Create browser session
             from Framework.Built_In_Automation.Web.utils import create_browser_session
-            session = create_browser_session(
+            create_browser_session(
                 session_name=session_name,
                 selenium_driver=selenium_driver,
                 playwright_page=playwright_page,

--- a/Framework/Built_In_Automation/Web/utils.py
+++ b/Framework/Built_In_Automation/Web/utils.py
@@ -1,6 +1,8 @@
 from Framework.Built_In_Automation.Shared_Resources import (
     BuiltInFunctionSharedResources as sr,
 )
+from playwright.async_api import Browser, BrowserContext, Frame, Page
+from selenium.webdriver import Chrome, Firefox, Edge, Safari
 
 
 
@@ -16,7 +18,7 @@ def initialize_browser_sessions():
 
 def create_browser_session(
     session_name: str = "default",
-    selenium_driver: WebDriver | None = None,
+    selenium_driver: Chrome | Firefox | Edge | Safari | None = None,
     playwright_page: Page | None = None,
     playwright_browser: Browser | None = None,
     playwright_context: BrowserContext | None = None,
@@ -28,7 +30,7 @@ def create_browser_session(
     
     Args:
         session_name (str): The name of the session.
-        selenium_driver (WebDriver): The Selenium WebDriver instance.
+        selenium_driver (Chrome | Firefox | Edge | Safari): The Selenium WebDriver instance.
         playwright_page (Page): The Playwright Page instance.
         playwright_browser (Browser): The Playwright Browser instance.
         playwright_context (BrowserContext): The Playwright BrowserContext instance.

--- a/Framework/Built_In_Automation/Web/utils.py
+++ b/Framework/Built_In_Automation/Web/utils.py
@@ -1,3 +1,6 @@
+import hashlib
+import socket
+
 from Framework.Built_In_Automation.Shared_Resources import (
     BuiltInFunctionSharedResources as sr,
 )
@@ -16,13 +19,80 @@ def initialize_browser_sessions():
         sr.Set_Shared_Variables("browser_sessions", {})
 
 
+def get_browser_sessions() -> dict:
+    """Return the browser session registry, initializing it when needed."""
+
+    if sr.Test_Shared_Variables("browser_sessions") == False:
+        initialize_browser_sessions()
+
+    browser_sessions = sr.Get_Shared_Variables("browser_sessions", log=False)
+    if not isinstance(browser_sessions, dict):
+        browser_sessions = {}
+        sr.Set_Shared_Variables("browser_sessions", browser_sessions)
+
+    return browser_sessions
+
+
+def extract_session_name(step_data) -> str | None:
+    """Return the optional browser session name from Zeuz step data."""
+
+    if not step_data:
+        return None
+
+    for left, mid, right in step_data:
+        left_l = left.replace(" ", "").replace("_", "").replace("-", "").lower()
+        if left_l == "session" and mid.strip().lower() == "optional parameter":
+            session_name = right.strip()
+            return session_name or None
+
+    return None
+
+
+def remove_browser_session(session_name: str) -> dict | None:
+    """Remove and return a browser session from the shared registry."""
+
+    browser_sessions = get_browser_sessions()
+    removed = browser_sessions.pop(session_name, None)
+    sr.Set_Shared_Variables("browser_sessions", browser_sessions)
+    return removed
+
+
+def is_port_in_use(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.2)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def get_debug_port(session_name: str, start: int = 9222, stop: int = 9322) -> int:
+    """Pick an available CDP port, preferring a stable session-name hash."""
+
+    used_ports = {
+        session.get("remote_debugging_port")
+        for session in get_browser_sessions().values()
+        if isinstance(session, dict) and session.get("remote_debugging_port")
+    }
+
+    port_range = stop - start + 1
+    port_hash = int(hashlib.md5(session_name.encode()).hexdigest(), 16)
+    first = start + (port_hash % port_range)
+    candidates = list(range(first, stop + 1)) + list(range(start, first))
+
+    for port in candidates:
+        if port not in used_ports and not is_port_in_use(port):
+            return port
+
+    raise RuntimeError(f"No available remote debugging port in range {start}-{stop}")
+
+
 def create_browser_session(
     session_name: str = "default",
     selenium_driver: Chrome | Firefox | Edge | Safari | None = None,
     playwright_page: Page | None = None,
     playwright_browser: Browser | None = None,
     playwright_context: BrowserContext | None = None,
-    playwright_frame: Frame | None = None
+    playwright_frame: Frame | None = None,
+    remote_debugging_port: int | None = None,
+    playwright_instance = None,
 ) -> dict:
     """
     Creates a new browser session with the given parameters.
@@ -37,16 +107,15 @@ def create_browser_session(
         playwright_frame (Frame): The Playwright Frame instance.
     """
     
-    if sr.Test_Shared_Variables("browser_sessions") == False:
-        initialize_browser_sessions()
-    
-    browser_sessions = sr.Get_Shared_Variables("browser_sessions")
+    browser_sessions = get_browser_sessions()
     browser_sessions[session_name] = {
         "selenium_driver": selenium_driver,
         "playwright_page": playwright_page,
         "playwright_browser": playwright_browser,
         "playwright_context": playwright_context,
-        "playwright_frame": playwright_frame
+        "playwright_frame": playwright_frame,
+        "playwright_instance": playwright_instance,
+        "remote_debugging_port": remote_debugging_port,
     }
     sr.Set_Shared_Variables("browser_sessions", browser_sessions)
 
@@ -64,8 +133,5 @@ def get_browser_session(session_name: str) -> dict:
         dict: The browser session with the given name.
     """
     
-    if sr.Test_Shared_Variables("browser_sessions") == False:
-        initialize_browser_sessions()
-    
-    browser_sessions = sr.Get_Shared_Variables("browser_sessions")
+    browser_sessions = get_browser_sessions()
     return browser_sessions.get(session_name, {})

--- a/Framework/Built_In_Automation/Web/utils.py
+++ b/Framework/Built_In_Automation/Web/utils.py
@@ -1,0 +1,69 @@
+from Framework.Built_In_Automation.Shared_Resources import (
+    BuiltInFunctionSharedResources as sr,
+)
+
+
+
+def initialize_browser_sessions():
+    """
+    Checks if `browser_sessions` shared variable is already initialized.
+    If not, initializes it as an empty dictionary.
+    """
+    
+    if sr.Test_Shared_Variables("browser_sessions") == False:
+        sr.Set_Shared_Variables("browser_sessions", {})
+
+
+def create_browser_session(
+    session_name: str = "default",
+    selenium_driver: WebDriver | None = None,
+    playwright_page: Page | None = None,
+    playwright_browser: Browser | None = None,
+    playwright_context: BrowserContext | None = None,
+    playwright_frame: Frame | None = None
+) -> dict:
+    """
+    Creates a new browser session with the given parameters.
+    Replaces the session if it already exists with the given name.
+    
+    Args:
+        session_name (str): The name of the session.
+        selenium_driver (WebDriver): The Selenium WebDriver instance.
+        playwright_page (Page): The Playwright Page instance.
+        playwright_browser (Browser): The Playwright Browser instance.
+        playwright_context (BrowserContext): The Playwright BrowserContext instance.
+        playwright_frame (Frame): The Playwright Frame instance.
+    """
+    
+    if sr.Test_Shared_Variables("browser_sessions") == False:
+        initialize_browser_sessions()
+    
+    browser_sessions = sr.Get_Shared_Variables("browser_sessions")
+    browser_sessions[session_name] = {
+        "selenium_driver": selenium_driver,
+        "playwright_page": playwright_page,
+        "playwright_browser": playwright_browser,
+        "playwright_context": playwright_context,
+        "playwright_frame": playwright_frame
+    }
+    sr.Set_Shared_Variables("browser_sessions", browser_sessions)
+
+    return browser_sessions[session_name]
+
+
+def get_browser_session(session_name: str) -> dict:
+    """
+    Returns the browser session with the given name.
+    
+    Args:
+        session_name (str): The name of the session.
+    
+    Returns:
+        dict: The browser session with the given name.
+    """
+    
+    if sr.Test_Shared_Variables("browser_sessions") == False:
+        initialize_browser_sessions()
+    
+    browser_sessions = sr.Get_Shared_Variables("browser_sessions")
+    return browser_sessions.get(session_name, {})

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -870,7 +870,9 @@ def set_screenshot_vars(shared_variables):
                     "driver"
                 ]  # Driver for selected device
         if screen_capture_type == "web":  # Selenium or Playwright driver object
-            if "selenium_driver" in shared_variables:
+            if shared_variables.get("active_web_driver_type") == "playwright" and "playwright_page" in shared_variables:
+                screen_capture_driver = shared_variables["playwright_page"]
+            elif "selenium_driver" in shared_variables:
                 screen_capture_driver = shared_variables["selenium_driver"]
             elif "playwright_page" in shared_variables:
                 screen_capture_driver = shared_variables["playwright_page"]

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -1,0 +1,106 @@
+from unittest.mock import MagicMock
+
+from Framework.Built_In_Automation.Shared_Resources import (
+    BuiltInFunctionSharedResources as sr,
+)
+from Framework.Built_In_Automation.Web import utils as browser_utils
+from Framework.Built_In_Automation.Web.Playwright import BuiltInFunctions as playwright_bif
+from Framework.Built_In_Automation.Web.Selenium import BuiltInFunctions as selenium_bif
+
+
+def setup_function():
+    sr.shared_variables.clear()
+    selenium_bif.selenium_driver = None
+    selenium_bif.current_driver_id = None
+    selenium_bif.selenium_details = {}
+    playwright_bif.current_page = None
+    playwright_bif.current_page_id = None
+    playwright_bif.context = None
+    playwright_bif.browser = None
+    playwright_bif.playwright_details = {}
+
+
+def test_selenium_session_activation_selects_driver():
+    driver = MagicMock()
+    browser_utils.create_browser_session(
+        session_name="admin",
+        selenium_driver=driver,
+        remote_debugging_port=9231,
+    )
+
+    result = selenium_bif._activate_browser_session_for_action(
+        [("session", "optional parameter", "admin")],
+        "Click_Element",
+    )
+
+    assert result == "passed"
+    assert selenium_bif.selenium_driver is driver
+    assert selenium_bif.current_driver_id == "admin"
+    assert sr.Get_Shared_Variables("selenium_driver") is driver
+    assert sr.Get_Shared_Variables("active_web_driver_type") == "selenium"
+    assert selenium_bif.selenium_details["admin"]["remote-debugging-port"] == 9231
+
+
+def test_selenium_missing_explicit_session_fails_non_create_action():
+    result = selenium_bif._activate_browser_session_for_action(
+        [("session", "optional parameter", "missing")],
+        "Click_Element",
+    )
+
+    assert result == "zeuz_failed"
+
+
+def test_selenium_missing_explicit_session_allowed_for_browser_creation():
+    result = selenium_bif._activate_browser_session_for_action(
+        [("session", "optional parameter", "new_user")],
+        "Go_To_Link",
+    )
+
+    assert result == "passed"
+
+
+def test_playwright_session_activation_selects_page_and_frame():
+    page = MagicMock()
+    context = MagicMock()
+    browser = MagicMock()
+    frame = MagicMock()
+    selenium_driver = MagicMock()
+    browser_utils.create_browser_session(
+        session_name="buyer",
+        selenium_driver=selenium_driver,
+        playwright_page=page,
+        playwright_context=context,
+        playwright_browser=browser,
+        playwright_frame=frame,
+    )
+
+    result = playwright_bif._activate_browser_session_for_action(
+        [("session", "optional parameter", "buyer")],
+        "Hover_Over_Element",
+    )
+
+    assert result == "passed"
+    assert playwright_bif.current_page is page
+    assert playwright_bif.context is context
+    assert playwright_bif.browser is browser
+    assert playwright_bif.current_page_id == "buyer"
+    assert sr.Get_Shared_Variables("playwright_frame") is frame
+    assert sr.Get_Shared_Variables("active_web_driver_type") == "playwright"
+
+
+def test_playwright_missing_explicit_session_fails_non_create_action():
+    result = playwright_bif._activate_browser_session_for_action(
+        [("session", "optional parameter", "missing")],
+        "Validate_Text",
+    )
+
+    assert result == "zeuz_failed"
+
+
+def test_remove_browser_session_updates_registry():
+    browser_utils.create_browser_session("temp", selenium_driver=MagicMock())
+
+    removed = browser_utils.remove_browser_session("temp")
+
+    assert removed is not None
+    assert browser_utils.get_browser_session("temp") == {}


### PR DESCRIPTION
This PR introduces session-based browser isolation to allow testers to easily spawn fresh browser windows and intuitively interact with them individually. It follows the same _session_ model used in database actions.

---

### Changes

* **Session Isolation**: Added `browser_sessions` shared variable to hold necessary browser driver information whenever opening new browser windows. By default, generates a `browser_session` named `default`.
* **Existing Variables**: The sessions simply contains the pointers to the driver variables that were already in use.
* **Dynamic Ports**: Automatically assigns unique remote debugging ports (9222–9322) for dual-driver CDP connections.
* **Dual Driver Support**: Implemented in both Selenium and Playwright. Commonly used actions were modified to check if session is available and switches the active driver accordingly.
* **Targeted Actions & Teardown**: Web functions now accept a `session` parameter to only execute the actions on specific instances without affecting others.

### Backwards Compatibility

* **No Breaking Changes**: If the `session` parameter is omitted, the framework defaults to the legacy single-instance behavior.
* **Legacy Parameters**: `driverid` support is maintained for Selenium.

---

## Usage

Add row in action in this format: `session` | `optional parameter` | `session name (string)`

### 1. Selenium Multi-Session

Pass a unique string to the `session` parameter to spawn separate windows.

```python
# Session A
Go_To_Link([
    ("session", "optional parameter", "user_1"),
    ("go to link", "selenium action", "https://google.com")
])

# Session B
Go_To_Link([
    ("session", "optional parameter", "user_2"),
    ("go to link", "selenium action", "https://bing.com")
])

```

### 2. Apply action on specific session
```python
# Will apply the click action on the browser with session name admin_auth
# even when there are multiple sessions active
Click_Element([
    ("session", "optional parameter", "admin_auth"),
    ("id", "element parameter", "login-btn"),
    ("click", "playwright action", "click")
])

```

### 3. Specific Session Cleanup

```python
Tear_Down_Selenium([
    ("session", "optional parameter", "user_1"),
    ("tear down", "selenium action", "tear down")
])
```
### 4. Without "session" parameter

Omitting the `session` parameter in step/action data will preserve the behavior as it was before the addition of this feature.
