### PR TITLE
Added Auto Ping after interval and ping timeout for improved stability

### DIFF
--- a/Framework/Utilities/live_log_service.py
+++ b/Framework/Utilities/live_log_service.py
@@ -233,7 +233,11 @@ def run_ws_thread():
             next_ws = _build_websocket(ws_url)
             with connection_lock:
                 ws = next_ws
-            next_ws.run_forever(sslopt={"cert_reqs": ssl.CERT_NONE})
+            next_ws.run_forever(
+                sslopt={"cert_reqs": ssl.CERT_NONE},
+                ping_interval=15,
+                ping_timeout=10
+            )
         except Exception as e:
             _log(f"Connection attempt failed: {e}")
         finally:


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
Feature

## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

This change introduces automatic WebSocket ping mechanisms within the `run_ws_thread` function in `live_log_service.py` to enhance connection stability for nodes that might experience long periods of inactivity or network fluctuations.

Previously, the `run_forever` method for the WebSocket connection lacked explicit heartbeat mechanisms, which could lead to connections timing out silently or becoming stale without proper re-establishment, resulting in service disruption.

This PR configures `next_ws.run_forever()` to include `ping_interval=15` seconds and `ping_timeout=10` seconds. This mandates that a ping frame is sent every 15 seconds, and if a pong is not received within 10 seconds, the connection will be closed and a reconnection attempt initiated. This proactive monitoring improves the resilience against dropped connections managed by intermediary proxies or load balancers, leading to improved stability for frequently connecting/disconnecting scenarios.

No breaking changes are introduced; this is an enhancement to the underlying WebSocket management logic.

## Test Cases
- [TEST-0000](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-0000/)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->