### PR TITLE
Added index support in data collector

### DIFF
--- a/Framework/Built_In_Automation/Shared_Resources/BuiltInFunctionSharedResources.py
+++ b/Framework/Built_In_Automation/Shared_Resources/BuiltInFunctionSharedResources.py
@@ -566,6 +566,7 @@ def parse_variable(name):
             # Data collector with pattern.
             # Match with the following pattern.
             # var_name{pattern1}{pattern2}{...}
+            # Optional post-indexing: var_name{pattern}[0] to get single value
 
             name = name[: name.find("{")]
             val = Get_Shared_Variables(name, log=False)
@@ -573,15 +574,30 @@ def parse_variable(name):
             if val == "zeuz_failed":
                 return "zeuz_failed"
 
+            # Separate {} collector patterns from trailing [] post-indices
+            rest = copy_of_name[copy_of_name.find("{"):]
+            last_brace = rest.rfind("}")
+            trailing = rest[last_brace + 1:] if last_brace >= 0 else ""
+            collector_patterns = re.findall(r"\{(.*?)\}", rest)
+            post_indices = re.findall(r"\[(.*?)\]", trailing)
+
             result = []
 
-            for idx in indices:
+            for idx in collector_patterns:
                 result.append(data_collector.collect(idx, val, "pattern"))
 
-            if len(indices) > 1:
+            if len(collector_patterns) > 1:
                 result = list(zip(*result))
-            elif len(indices) == 1:
+            elif len(collector_patterns) == 1:
                 result = result[0]
+
+            # Apply post-indexing if specified (e.g., var{pattern}[0] to get single value)
+            for idx in post_indices:
+                try:
+                    result = result[int(idx)]
+                except (ValueError, IndexError, TypeError) as e:
+                    CommonUtil.ExecLog(sModuleInfo, "Post-index [%s] could not be applied to data collector result: %s" % (idx, str(e)), 3)
+                    return "zeuz_failed"
 
              # send variable value in report logs and terminal
             if str(shared_variables['zeuz_enable_variable_logging']).lower() in {"on", "yes", "true", "1"}:
@@ -595,6 +611,7 @@ def parse_variable(name):
             # Data collector with keys.
             # Match with the following pattern.
             # var_name(pattern1)(pattern2)(...)
+            # Optional post-indexing: var_name(key)[0] to get single value
 
             name = name[: name.find("(")]
             val = Get_Shared_Variables(name, log=False)
@@ -602,13 +619,35 @@ def parse_variable(name):
             if val == "zeuz_failed":
                 return "zeuz_failed"
 
+            # Separate () collector patterns from trailing [] post-indices
+            rest = copy_of_name[copy_of_name.find("("):]
+            last_paren = rest.rfind(")")
+            trailing = rest[last_paren + 1:] if last_paren >= 0 else ""
+            collector_patterns = re.findall(r"\((.*?)\)", rest)
+            post_indices = re.findall(r"\[(.*?)\]", trailing)
+
             result = []
 
-            for idx in indices:
+            for idx in collector_patterns:
                 result.append(data_collector.collect(idx, val, "key"))
 
-            if len(indices) == 1:
+            if len(collector_patterns) == 1:
                 result = result[0]
+
+            # Apply post-indexing if specified (e.g., var(key)['line'][0] to get single value)
+            for idx in post_indices:
+                try:
+                    result = result[int(idx)]
+                except ValueError:
+                    # Try string key access (e.g., var(key)['line'])
+                    try:
+                        result = result[idx.strip("'\"")]
+                    except (KeyError, TypeError, IndexError) as e:
+                        CommonUtil.ExecLog(sModuleInfo, "Post-index [%s] could not be applied to key collector result: %s" % (idx, str(e)), 3)
+                        return "zeuz_failed"
+                except (IndexError, TypeError) as e:
+                    CommonUtil.ExecLog(sModuleInfo, "Post-index [%s] could not be applied to key collector result: %s" % (idx, str(e)), 3)
+                    return "zeuz_failed"
 
             if str(shared_variables['zeuz_enable_variable_logging']).lower() in {"on", "yes", "true", "1"}:
                 CommonUtil.AddVariableToLog(sModuleInfo, copy_of_name, result)


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
Feature

## PR Checklist
<!-- Check your PR fulfills the following items. ->>
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
This PR introduces support for post-indexing data collector results using square bracket notation (`[index]`) immediately following the collector patterns (curly braces `{}` or parentheses `()`).

Previously, data collectors returned their result set, which could be a list of values (for multiple patterns) or a single value. This change allows users to directly access a specific element from the collected result set using trailing indices, enabling the retrieval of a single value directly without intermediate variable assignment.

For pattern collection (`var{p1}{p2}`), post-indexing like `var{p1}{p2}[0]` now accesses the first element of the zipped result set. For key collection (`var(k1)(k2)`), post-indexing like `var(k1)(k2)[0]` accesses the indexed element of the resulting structure. Error handling is added for invalid indices or types during post-indexing application.

## Test Cases
- [TEST-0000] (Placeholder for specific test case reference if available)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->