### PR TITLE
Implement screenshot capture with fallback to full screen

### DIFF
--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -978,6 +978,38 @@ def _wait_for_debug_screenshot_delay(sModuleInfo, function_name, Method):
     return True
 
 
+def _get_window_screenshot_bbox():
+    """ Try to find window title from step_data and return its bounding box if found """
+    try:
+        if sys.platform != "win32":
+            return None
+        import pygetwindow as gw
+        from Framework.Built_In_Automation.Shared_Resources import BuiltInFunctionSharedResources as shared
+        
+        window_title = None
+        step_data = shared.Get_Shared_Variables("step_data", False)
+        if step_data and current_action_no and str(current_action_no).isdigit():
+            current_dataset = step_data[int(current_action_no) - 1]
+            for row in current_dataset:
+                left = str(row[0]).strip().lower()
+                if "window" in left:
+                    window_title = str(row[2])
+                    break
+                if "open app" in left:
+                    window_title = str(row[2])
+                    # not breaking because window is more preferred
+                    
+        if window_title:
+            windows = gw.getWindowsWithTitle(window_title)
+            if windows:
+                win = windows[0]
+                return (win.left, win.top, win.right, win.bottom)
+        
+    except Exception:
+        pass
+    return None
+
+
 def Thread_ScreenShot(function_name, image_folder, Method, Driver, image_name):
     """ Capture screen of mobile or desktop """
     if performance_testing: return
@@ -1025,7 +1057,8 @@ def Thread_ScreenShot(function_name, image_folder, Method, Driver, image_name):
                 image = ImageGrab_Linux.grab()
                 image.save(ImageName, format="PNG")  # Save to disk
             elif sys.platform == "win32" or sys.platform == "darwin":
-                image = ImageGrab_Mac_Win.grab()
+                bbox = _get_window_screenshot_bbox()
+                image = ImageGrab_Mac_Win.grab(bbox)
                 image.save(ImageName, format="PNG")  # Save to disk
 
         # Capture screenshot of web browser

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -1003,6 +1003,17 @@ def _get_window_screenshot_bbox():
             windows = gw.getWindowsWithTitle(window_title)
             if windows:
                 win = windows[0]
+                try:
+                    if win.isMinimized:
+                        win.restore()
+                    try:
+                        import autoit
+                        autoit.win_activate(win.title)
+                    except Exception:
+                        win.activate()
+                    time.sleep(0.5) # Allow time for window to render in foreground
+                except Exception:
+                    pass
                 return (win.left, win.top, win.right, win.bottom)
         
     except Exception:


### PR DESCRIPTION
<!-- Thanks for considering contributing Zeuz Node! -->
<!-- Please fill out the following to get your PR reviewed quicker. -->

## PR Type
Feature


## PR Checklist
- [ ] Documentation comments have been added / updated.
- [ ] Tests for the changes have been added / updated.
- [ ] A changelog entry has been made.
- [ ] Version number has been updated.
- [ ] Required modules have been added to respective "requirements*.txt" files.
- [ ] Relevant Test Cases added to this description (below).
- [ ] (Team) Label with affected action categories and semver status.


## Overview
This PR implements targeted application window screenshots for Windows automation, moving away from forced full-screen captures.

### Changes:
- **Refactored Screenshot Logic**: Extracted targeted window coordinate fetching into a dedicated internal function `_get_window_screenshot_bbox` in `CommonUtil.py`.
- **Intelligent Window Identification**: The framework now parses the current action's dataset to find "window" or "open app" rows to determine the target application title.
- **Improved Foreground Reliability**: Integrated `autoit.win_activate()` to reliably bring the target application to the foreground before capture, bypassing Windows focus-stealing protections that often block standard APIs.
- **Automatic Fallback**: Maintained a robust fallback to full-screen capture if the window title is missing, the window is not found, or focus cannot be acquired.
- **Safety Checks**: Added validation for `current_action_no` to prevent `ValueError` during dataset lookup.

## Test Cases
- [TEST-0000](https://zeuz.zeuz.ai/Home/ManageTestCases/Edit/TEST-0000/)

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
