### PR TITLE
Reporting fix for node initial Run

### DIFF
--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -483,7 +483,7 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
             log_id_vals = log_id.split("|")
             if logs:
                 log_id, now, iLogLevel, status, sModuleInfo, sDetails = logs
-            if not len(log_id_vals) == 4 and setInfo:
+            if setInfo:
                 print('\n\n ------ Set report investigation ------\n\n')
                 print('log_id:', log_id)
                 print('log_id_vals:', log_id_vals)

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -444,26 +444,6 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
         if logs or stepInfo or TCInfo or setInfo:
             log_id = ConfigModule.get_config_value("sectionOne", "sTestStepExecLogId", temp_config())
             # 'Wed-May-6-08:11:59-2026|TEST-0158|none|none'
-            if setInfo:
-                print('\n\n ------ Set report investigation ------\n\n')
-                print('log_id:', log_id)
-                print('setInfo:', json.dumps(setInfo, indent=2))
-
-                settings_conf_path = Path(os.path.join(os.path.abspath(__file__).split("Framework")[0])) / "Framework" / "settings.conf"
-                print('settings_conf_path:', settings_conf_path)
-                with open(settings_conf_path, 'r') as f:
-                    print('\n\n', f.read(), '\n\n')
-                    
-                advanced_options_file = ConfigModule.get_config_value(
-                    "Advanced Options",
-                    "_file",
-                )
-                print('advanced_options_file:', advanced_options_file)
-                print('temp_config:', temp_config())
-                with open(temp_config(), 'r') as f:
-                    print('\n\n', f.read(), '\n\n')
-
-                print('\n\n --------------------------------------\n\n')
             if not log_id:
                 return
             log_id_vals = log_id.split("|")

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -477,11 +477,20 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
         start = time.perf_counter()
         if logs or stepInfo or TCInfo or setInfo:
             log_id = ConfigModule.get_config_value("sectionOne", "sTestStepExecLogId", temp_config)
+            # 'Wed-May-6-08:11:59-2026|TEST-0158|none|none'
             if not log_id:
                 return
             log_id_vals = log_id.split("|")
             if logs:
                 log_id, now, iLogLevel, status, sModuleInfo, sDetails = logs
+            if not len(log_id_vals) == 4 and stepInfo:
+                print('\n\n ------ Set report investigation ------\n\n')
+                print('log_id:', log_id)
+                print('log_id_vals:', log_id_vals)
+                print('setInfo:', json.dumps(setInfo, indent=2))
+                with open(temp_config, 'r') as f:
+                    print('\n\n', f.read(), '\n\n')
+                print('\n\n --------------------------------------\n\n')
             if len(log_id_vals) == 4:
                 # these loops can be optimized by saving the previous log_id_vals and comparing it with current one
                 runID, testcase_no, step_id, step_no = log_id_vals

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -490,6 +490,11 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
                 print('temp_config:', temp_config)
                 with open(temp_config, 'r') as f:
                     print('\n\n', f.read(), '\n\n')
+
+                settings_conf_path = Path(os.path.join(os.path.abspath(__file__).split("Framework")[0])) / "Framework" / "settings.conf"
+                print('settings_conf_path:', settings_conf_path)
+                with open(settings_conf_path, 'r') as f:
+                    print('\n\n', f.read(), '\n\n')
                 print('\n\n --------------------------------------\n\n')
             if not log_id:
                 return

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -482,6 +482,12 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
                 print('\n\n ------ Set report investigation ------\n\n')
                 print('log_id:', log_id)
                 print('setInfo:', json.dumps(setInfo, indent=2))
+
+                settings_conf_path = Path(os.path.join(os.path.abspath(__file__).split("Framework")[0])) / "Framework" / "settings.conf"
+                print('settings_conf_path:', settings_conf_path)
+                with open(settings_conf_path, 'r') as f:
+                    print('\n\n', f.read(), '\n\n')
+                    
                 advanced_options_file = ConfigModule.get_config_value(
                     "Advanced Options",
                     "_file",
@@ -491,10 +497,6 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
                 with open(temp_config, 'r') as f:
                     print('\n\n', f.read(), '\n\n')
 
-                settings_conf_path = Path(os.path.join(os.path.abspath(__file__).split("Framework")[0])) / "Framework" / "settings.conf"
-                print('settings_conf_path:', settings_conf_path)
-                with open(settings_conf_path, 'r') as f:
-                    print('\n\n', f.read(), '\n\n')
                 print('\n\n --------------------------------------\n\n')
             if not log_id:
                 return

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -483,7 +483,7 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
             log_id_vals = log_id.split("|")
             if logs:
                 log_id, now, iLogLevel, status, sModuleInfo, sDetails = logs
-            if not len(log_id_vals) == 4 and stepInfo:
+            if not len(log_id_vals) == 4 and setInfo:
                 print('\n\n ------ Set report investigation ------\n\n')
                 print('log_id:', log_id)
                 print('log_id_vals:', log_id_vals)

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -58,16 +58,17 @@ console = Console()
 MODULE_NAME = inspect.getmodulename(__file__)
 
 # Get file path for temporary config file
-temp_config = Path(
-    os.path.join(os.path.abspath(__file__).split("Framework")[0])
-    / Path("AutomationLog")
-    / Path(
-        ConfigModule.get_config_value(
-            "Advanced Options",
-            "_file",
+def temp_config() -> Path:
+    return Path(
+        os.path.join(os.path.abspath(__file__).split("Framework")[0])
+        / Path("AutomationLog")
+        / Path(
+            ConfigModule.get_config_value(
+                "Advanced Options",
+                "_file",
+            )
         )
     )
-)
 
 common_modules = ["os", "sys", "platform", "time", "datetime", "random", "re", "uuid", "pathlib", "json", "ast", "yaml", "csv", "xml", "xlwings", "requests", "sr"]
 
@@ -328,41 +329,6 @@ def prettify(key, val):
         # 4 means console log which is Magenta color in server console
         live_log_service.log("VARIABLE", 4, expression.replace("\n", "<br>").replace(" ", "&nbsp;"))
 
-def Add_Folder_To_Current_Test_Case_Log(src):
-    try:
-        # get the current test case locations
-        dest_folder = ConfigModule.get_config_value(
-            "sectionOne", "test_case_folder", temp_config
-        )
-        folder_name = [x for x in src.split("/") if x != ""][-1]
-        if folder_name:
-            des_path = os.path.join(dest_folder, folder_name)
-            FL.copy_folder(src, des_path)
-            return True
-        else:
-            return False
-
-    except Exception as e:
-        return Exception_Handler(sys.exc_info())
-
-
-def Add_File_To_Current_Test_Case_Log(src):
-    try:
-        # get the current test case locations
-        dest_folder = ConfigModule.get_config_value(
-            "sectionOne", "test_case_folder", temp_config
-        )
-        file_name = [x for x in src.split("/") if x != ""][-1]
-        if file_name:
-            des_path = os.path.join(dest_folder, file_name)
-            FL.copy_file(src, des_path)
-            return True
-        else:
-            return False
-
-    except Exception as e:
-        return Exception_Handler(sys.exc_info())
-
 
 def strip1(original_value: str, remove: str) -> str:
     if original_value.startswith(remove):
@@ -476,7 +442,7 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
         global all_logs_json, report_json_time, tc_error_logs, passed_after_rerun, zeuz_tc_run_comment
         start = time.perf_counter()
         if logs or stepInfo or TCInfo or setInfo:
-            log_id = ConfigModule.get_config_value("sectionOne", "sTestStepExecLogId", temp_config)
+            log_id = ConfigModule.get_config_value("sectionOne", "sTestStepExecLogId", temp_config())
             # 'Wed-May-6-08:11:59-2026|TEST-0158|none|none'
             if setInfo:
                 print('\n\n ------ Set report investigation ------\n\n')
@@ -493,8 +459,8 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
                     "_file",
                 )
                 print('advanced_options_file:', advanced_options_file)
-                print('temp_config:', temp_config)
-                with open(temp_config, 'r') as f:
+                print('temp_config:', temp_config())
+                with open(temp_config(), 'r') as f:
                     print('\n\n', f.read(), '\n\n')
 
                 print('\n\n --------------------------------------\n\n')
@@ -716,7 +682,7 @@ def ExecLog(
     if iLogLevel > 0:
         if iLogLevel == 6:
             FWLogFolder = ConfigModule.get_config_value(
-                "sectionOne", "log_folder", temp_config
+                "sectionOne", "log_folder", temp_config()
             )
             if os.path.exists(FWLogFolder) == False:
                 FL.CreateFolder(FWLogFolder)  # Create log directory if missing
@@ -724,7 +690,7 @@ def ExecLog(
             if FWLogFolder == "":
                 BrowserConsoleLogFile = (
                     ConfigModule.get_config_value(
-                        "sectionOne", "temp_run_file_path", temp_config
+                        "sectionOne", "temp_run_file_path", temp_config()
                     )
                     + os.sep
                     + "BrowserLog.log"
@@ -777,7 +743,7 @@ def ExecLog(
                 
 
             log_id = ConfigModule.get_config_value(
-                "sectionOne", "sTestStepExecLogId", temp_config
+                "sectionOne", "sTestStepExecLogId", temp_config()
             )
             if not log_id:
                 return
@@ -805,7 +771,7 @@ def ExecLog(
                     filepath = (
                         Path(
                             ConfigModule.get_config_value(
-                                "sectionOne", "temp_run_file_path", temp_config
+                                "sectionOne", "temp_run_file_path", temp_config()
                             )
                         )
                         / "execution.log"
@@ -910,7 +876,7 @@ def TakeScreenShot(function_name, local_run=False):
         sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
         # Read values from config file
         take_screenshot_settings = ConfigModule.get_config_value("RunDefinition", "take_screenshot")
-        image_folder = ConfigModule.get_config_value("sectionOne", "screen_capture_folder", temp_config)
+        image_folder = ConfigModule.get_config_value("sectionOne", "screen_capture_folder", temp_config())
 
         try:
             if not os.path.exists(image_folder):

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -478,19 +478,18 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
         if logs or stepInfo or TCInfo or setInfo:
             log_id = ConfigModule.get_config_value("sectionOne", "sTestStepExecLogId", temp_config)
             # 'Wed-May-6-08:11:59-2026|TEST-0158|none|none'
+            if setInfo:
+                print('\n\n ------ Set report investigation ------\n\n')
+                print('log_id:', log_id)
+                print('setInfo:', json.dumps(setInfo, indent=2))
+                with open(temp_config, 'r') as f:
+                    print('\n\n', f.read(), '\n\n')
+                print('\n\n --------------------------------------\n\n')
             if not log_id:
                 return
             log_id_vals = log_id.split("|")
             if logs:
                 log_id, now, iLogLevel, status, sModuleInfo, sDetails = logs
-            if setInfo:
-                print('\n\n ------ Set report investigation ------\n\n')
-                print('log_id:', log_id)
-                print('log_id_vals:', log_id_vals)
-                print('setInfo:', json.dumps(setInfo, indent=2))
-                with open(temp_config, 'r') as f:
-                    print('\n\n', f.read(), '\n\n')
-                print('\n\n --------------------------------------\n\n')
             if len(log_id_vals) == 4:
                 # these loops can be optimized by saving the previous log_id_vals and comparing it with current one
                 runID, testcase_no, step_id, step_no = log_id_vals

--- a/Framework/Utilities/CommonUtil.py
+++ b/Framework/Utilities/CommonUtil.py
@@ -482,6 +482,12 @@ def CreateJsonReport(logs=None, stepInfo=None, TCInfo=None, setInfo=None):
                 print('\n\n ------ Set report investigation ------\n\n')
                 print('log_id:', log_id)
                 print('setInfo:', json.dumps(setInfo, indent=2))
+                advanced_options_file = ConfigModule.get_config_value(
+                    "Advanced Options",
+                    "_file",
+                )
+                print('advanced_options_file:', advanced_options_file)
+                print('temp_config:', temp_config)
                 with open(temp_config, 'r') as f:
                     print('\n\n', f.read(), '\n\n')
                 print('\n\n --------------------------------------\n\n')


### PR DESCRIPTION
### Summary:
When a zeuz node is downloaded and run for the first time, It might happen that settings.conf inside framework file was imported before the file is created. This invokes an reporting error. The error is fixed