### PR TITLE
Playwright-Selenium feature parity

### DIFF
--- a/Framework/Built_In_Automation/Sequential_Actions/action_declarations/playwright.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/action_declarations/playwright.py
@@ -11,6 +11,7 @@ Author: Zeuz/AutomationSolutionz
 declarations = (
     # Browser Management
     { "name": "open browser",                  "function": "Open_Browser",               "screenshot": "web" },
+    { "name": "open electron app",             "function": "Open_Electron_App",          "screenshot": "web" },
     { "name": "go to link",                    "function": "Go_To_Link",                 "screenshot": "web" },
     { "name": "tear down browser",             "function": "Tear_Down_Playwright",       "screenshot": "none" },
     { "name": "teardown",                      "function": "Tear_Down_Playwright",       "screenshot": "none" },
@@ -34,6 +35,7 @@ declarations = (
 
     # Element Information
     { "name": "save attribute",                "function": "Save_Attribute",             "screenshot": "web" },
+    { "name": "change attribute value",        "function": "Change_Attribute_Value",       "screenshot": "web" },
     { "name": "get element info",              "function": "get_element_info",           "screenshot": "web" },
     { "name": "extract table data",            "function": "Extract_Table_Data",         "screenshot": "web" },
 
@@ -45,6 +47,11 @@ declarations = (
     { "name": "scroll",                        "function": "Scroll",                     "screenshot": "web" },
     { "name": "scroll to element",             "function": "scroll_to_element",          "screenshot": "web" },
     { "name": "scroll element to top",         "function": "scroll_to_element",          "screenshot": "web" },
+    { "name": "scroll to top",                 "function": "scroll_to_top",              "screenshot": "web" },
+
+    # Lists / attributes
+    { "name": "save attribute values in list", "function": "save_attribute_values_in_list", "screenshot": "web" },
+    { "name": "save web elements in list",     "function": "save_web_elements_in_list",     "screenshot": "web" },
 
     # Selection (Dropdowns/Checkboxes)
     { "name": "select by visible text",        "function": "Select_Deselect",            "screenshot": "web" },
@@ -55,6 +62,7 @@ declarations = (
     { "name": "deselect by index",             "function": "Select_Deselect",            "screenshot": "web" },
     { "name": "deselect all",                  "function": "Select_Deselect",            "screenshot": "web" },
     { "name": "check uncheck",                 "function": "check_uncheck",              "screenshot": "web" },
+    { "name": "multiple check uncheck",        "function": "multiple_check_uncheck",        "screenshot": "web" },
 
     # Window/Tab Management
     { "name": "switch window",                 "function": "switch_window_or_tab",       "screenshot": "web" },

--- a/Framework/Built_In_Automation/Sequential_Actions/action_declarations/playwright.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/action_declarations/playwright.py
@@ -13,6 +13,7 @@ declarations = (
     { "name": "open browser",                  "function": "Open_Browser",               "screenshot": "web" },
     { "name": "open electron app",             "function": "Open_Electron_App",          "screenshot": "web" },
     { "name": "go to link",                    "function": "Go_To_Link",                 "screenshot": "web" },
+    { "name": "go to link v2",                 "function": "Go_To_Link_V2",              "screenshot": "web" },
     { "name": "tear down browser",             "function": "Tear_Down_Playwright",       "screenshot": "none" },
     { "name": "teardown",                      "function": "Tear_Down_Playwright",       "screenshot": "none" },
     { "name": "switch browser",                "function": "Switch_Browser",             "screenshot": "none" },
@@ -22,6 +23,7 @@ declarations = (
     { "name": "double click",                  "function": "Double_Click_Element",       "screenshot": "web" },
     { "name": "right click",                   "function": "Right_Click_Element",        "screenshot": "web" },
     { "name": "hover",                         "function": "Hover_Over_Element",         "screenshot": "web" },
+    { "name": "click and download",            "function": "Click_and_Download",         "screenshot": "web" },
 
     # Text Input
     { "name": "text",                          "function": "Enter_Text_In_Text_Box",     "screenshot": "web" },
@@ -36,6 +38,7 @@ declarations = (
     # Element Information
     { "name": "save attribute",                "function": "Save_Attribute",             "screenshot": "web" },
     { "name": "change attribute value",        "function": "Change_Attribute_Value",       "screenshot": "web" },
+    { "name": "capture network log",           "function": "capture_network_log",        "screenshot": "web" },
     { "name": "get element info",              "function": "get_element_info",           "screenshot": "web" },
     { "name": "extract table data",            "function": "Extract_Table_Data",         "screenshot": "web" },
 
@@ -62,7 +65,9 @@ declarations = (
     { "name": "deselect by index",             "function": "Select_Deselect",            "screenshot": "web" },
     { "name": "deselect all",                  "function": "Select_Deselect",            "screenshot": "web" },
     { "name": "check uncheck",                 "function": "check_uncheck",              "screenshot": "web" },
+    { "name": "check uncheck all",             "function": "check_uncheck_all",          "screenshot": "web" },
     { "name": "multiple check uncheck",        "function": "multiple_check_uncheck",        "screenshot": "web" },
+    { "name": "slider bar",                    "function": "slider_bar",                 "screenshot": "web" },
 
     # Window/Tab Management
     { "name": "switch window",                 "function": "switch_window_or_tab",       "screenshot": "web" },
@@ -88,6 +93,7 @@ declarations = (
 
     # File Upload
     { "name": "upload file",                   "function": "upload_file",                "screenshot": "web" },
+    { "name": "copy image into browser",       "function": "copy_image_into_browser",    "screenshot": "web" },
 
     # Window Management
     { "name": "resize window",                 "function": "resize_window",              "screenshot": "web" },

--- a/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
+++ b/Framework/Built_In_Automation/Sequential_Actions/common_functions.py
@@ -3723,7 +3723,7 @@ def _print(*args, sep=' ', end='\n', file=None, dont_send=False):
 
 
 @logger
-def execute_python_code(data_set):
+async def execute_python_code(data_set):
     try:
         sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
         inp, out_var, main_function, Code, filepath_code = "", "", "", "", ""
@@ -3749,10 +3749,31 @@ def execute_python_code(data_set):
 
         Code = filepath_code if filepath_code else Code
         sr.shared_variables["print"] = _print
+        try:
+            from Framework.Built_In_Automation.Web import utils as WebUtils
+
+            await WebUtils.hydrate_browser_compatibility_globals(data_set)
+        except Exception:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                "Could not hydrate browser compatibility globals before executing python code",
+                2,
+            )
+            CommonUtil.Exception_Handler(sys.exc_info())
         previous_vars = set(sr.shared_variables)
 
-        try: exec(Code, sr.shared_variables)
-        except: return CommonUtil.Exception_Handler(sys.exc_info())
+        try:
+            compiled_code = compile(
+                Code,
+                "<execute_python_code>",
+                "exec",
+                flags=ast.PyCF_ALLOW_TOP_LEVEL_AWAIT,
+            )
+            exec_result = eval(compiled_code, sr.shared_variables)
+            if inspect.isawaitable(exec_result):
+                await exec_result
+        except:
+            return CommonUtil.Exception_Handler(sys.exc_info())
 
         try:
             current_vars = set(sr.shared_variables)

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -26,25 +26,25 @@ import os
 import inspect
 import platform
 import time
-import re
+import base64
 from pathlib import Path
+from urllib.parse import urlparse
 
 from playwright.async_api import (
     async_playwright,
     Page,
     Browser,
     BrowserContext,
-    Locator,
     TimeoutError as PlaywrightTimeoutError,
     Error as PlaywrightError,
 )
 
-from Framework.Utilities import CommonUtil
+from Framework.Utilities import CommonUtil, ConfigModule
 from Framework.Utilities.decorators import logger
 from Framework.Built_In_Automation.Shared_Resources import (
     BuiltInFunctionSharedResources as sr,
 )
-from Framework.Utilities.CommonUtil import passed_tag_list, failed_tag_list
+from Framework.Utilities.CommonUtil import failed_tag_list
 from . import locator as PlaywrightLocator
 from . import utils as PlaywrightUtils
 from Framework.Built_In_Automation.Web.utils import (
@@ -63,7 +63,7 @@ def _get_frame_locator():
         if frame_locator in failed_tag_list:
             return None
         return frame_locator
-    except:
+    except Exception:
         # Variable doesn't exist yet
         return None
 
@@ -204,6 +204,12 @@ def connect_selenium_to_playwright(port=9222):
 
 MODULE_NAME = inspect.getmodulename(__file__)
 
+temp_config = str(
+    Path(os.path.abspath(__file__).split("Framework")[0])
+    / "AutomationLog"
+    / ConfigModule.get_config_value("Advanced Options", "_file")
+)
+
 # Playwright instances
 playwright_instance = None
 browser: Browser = None
@@ -213,10 +219,75 @@ current_page: Page = None
 # Multi-page/context support
 playwright_details = {}  # {"page_id": {"page": Page, "context": Context, "browser": Browser}}
 current_page_id = None
+network_log_details = {}
 
 # Default settings
 default_timeout = 30000  # 30 seconds
 default_viewport = {"width": 1920, "height": 1080}
+
+
+def _compact(value):
+    return str(value).replace(" ", "").replace("_", "").replace("-", "").lower()
+
+
+def _is_action_mid(mid):
+    return "action" in str(mid).strip().lower()
+
+
+def _truthy(value):
+    return str(value).strip().lower() in ("true", "yes", "ok", "1", "accept")
+
+
+def _is_placeholder(value, *placeholders):
+    value_l = str(value).strip().lower()
+    return not value_l or value_l in placeholders or value_l == "default"
+
+
+def _has_element_rows(step_data):
+    return any(_is_element_parameter_mid(mid) for _, mid, _ in step_data)
+
+
+def _action_row_value(step_data, *action_names):
+    names = {name.strip().lower() for name in action_names}
+    for left, mid, right in step_data:
+        if _is_action_mid(mid) and (not names or left.strip().lower() in names):
+            return str(right)
+    return None
+
+
+def _save_variable_from_action_or_save_parameter(step_data, *action_names):
+    save_variable = None
+    for left, mid, right in step_data:
+        mid_l = str(mid).strip().lower()
+        if mid_l == "save parameter":
+            save_variable = str(left).strip()
+        elif _is_action_mid(mid) and (not action_names or left.strip().lower() in action_names):
+            value = str(right).strip()
+            if not _is_placeholder(value, left.strip().lower()):
+                save_variable = value
+    return save_variable
+
+
+def _screenshot_folder():
+    try:
+        folder = ConfigModule.get_config_value("sectionOne", "screen_capture_folder", temp_config)
+        if folder:
+            Path(folder).mkdir(parents=True, exist_ok=True)
+            return folder
+    except Exception:
+        pass
+    return os.getcwd()
+
+
+def _download_folder():
+    try:
+        folder = sr.Get_Shared_Variables("zeuz_download_folder")
+        if folder not in failed_tag_list:
+            Path(folder).mkdir(parents=True, exist_ok=True)
+            return folder
+    except Exception:
+        pass
+    return os.getcwd()
 
 
 #########################
@@ -292,7 +363,10 @@ async def Open_Browser(step_data):
     try:
         # Parse parameters
         url = None
+        dependency = sr.Get_Shared_Variables("dependency")
         browser_name = "chromium"
+        if isinstance(dependency, dict) and dependency.get("Browser"):
+            browser_name = dependency["Browser"].strip().lower().replace("headless", "").strip() or browser_name
         headless = False
         viewport = default_viewport.copy()
         args = []
@@ -319,7 +393,7 @@ async def Open_Browser(step_data):
                     url = right_v
                 elif left_l in ("browser", "browser name"):
                     browser_name = right_v.lower()
-                elif left_l in ("driver id", "page id", "driver tag", "session"):
+                elif _compact(left_l) in ("driverid", "pageid", "drivertag", "session"):
                     page_id = right_v
 
             elif mid_l == "optional parameter":
@@ -350,7 +424,7 @@ async def Open_Browser(step_data):
                     color_scheme = right_v
                 elif left_l == "permission":
                     permissions.append(right_v)
-                elif left_l in ("driver id", "page id", "driver tag", "session"):
+                elif _compact(left_l) in ("driverid", "pageid", "drivertag", "session"):
                     page_id = right_v    
 
             elif mid_l == "shared capability":
@@ -405,7 +479,7 @@ async def Open_Browser(step_data):
             browser = await playwright_instance.chromium.launch(**launch_options)
 
         # Context options
-        context_options = {"viewport": viewport}
+        context_options = {"viewport": viewport, "accept_downloads": True}
         if record_video:
             context_options["record_video_dir"] = video_dir or "videos/"
         if locale:
@@ -664,7 +738,7 @@ async def Go_To_Link(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "optional parameter" and left_l == "session":
+            if mid_l == "optional parameter" and _compact(left_l) in ("session", "driverid", "driver", "drivertag", "pageid"):
                 session_name = right_v
                 break
 
@@ -718,7 +792,7 @@ async def Go_To_Link(step_data):
             if left_l in ("go to link", "url", "link"):
                 url = right_v
             elif mid_l == "optional parameter":
-                if left_l == "session":
+                if _compact(left_l) in ("session", "driverid", "driver", "drivertag", "pageid"):
                     continue
                 if left_l in ("wait until", "wait_until", "waituntil"):
                     wait_until = right_v.lower()
@@ -781,6 +855,28 @@ async def Go_To_Link(step_data):
 
 
 @logger
+async def Go_To_Link_V2(step_data):
+    """Selenium-compatible v2 navigation wrapper."""
+
+    translated = []
+    for left, mid, right in step_data:
+        left_l = left.strip().lower()
+        if left_l == "go to link v2":
+            translated.append(("go to link", mid, right))
+        elif left_l == "driver tag":
+            translated.append(("session", "optional parameter", right))
+        elif left_l == "page load timeout":
+            translated.append(("wait time to page load", "optional parameter", right))
+        elif left_l == "wait for element":
+            translated.append(("wait time to appear element", "optional parameter", right))
+        elif left_l == "page load strategy":
+            translated.append(("wait until", "optional parameter", right))
+        else:
+            translated.append((left, mid, right))
+    return await Go_To_Link(translated)
+
+
+@logger
 async def Tear_Down_Playwright(step_data=None):
     """
     Close browser and clean up Playwright resources.
@@ -807,7 +903,7 @@ async def Tear_Down_Playwright(step_data=None):
                 mid_l = mid.strip().lower()
                 right_v = right.strip()
                 
-                if mid_l == "optional parameter" and left_l == "session":
+                if mid_l == "optional parameter" and _compact(left_l) in ("session", "driverid", "driver", "drivertag", "pageid"):
                     session_name = right_v
                     break
         
@@ -839,7 +935,7 @@ async def Tear_Down_Playwright(step_data=None):
                             pass
                     
                     CommonUtil.ExecLog(sModuleInfo, f"Teared down session '{session_name}'", 1)
-                except Exception as e:
+                except Exception:
                     errMsg = f"Unable to tear down session '{session_name}'. may already been killed"
                     CommonUtil.ExecLog(sModuleInfo, errMsg, 2)
                 
@@ -973,12 +1069,11 @@ async def Switch_Browser(step_data):
             right_v = right.strip()
 
             if mid_l in ("input parameter", "optional parameter"):
-                if left_l in ("driver id", "page id", "driver tag", "session"):
+                if _compact(left_l) in ("driverid", "pageid", "drivertag", "session"):
                     target_id = right_v
 
         if not target_id:
-            CommonUtil.ExecLog(sModuleInfo, "No driver/page ID provided", 3)
-            return "zeuz_failed"
+            target_id = "default"
 
         existing_session = get_browser_session(target_id)
         if existing_session and existing_session.get("playwright_page"):
@@ -1307,6 +1402,60 @@ async def Hover_Over_Element(step_data):
         return CommonUtil.Exception_Handler(sys.exc_info())
 
 
+@logger
+async def Click_and_Download(data_set):
+    """Click an element and wait for a browser download."""
+
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global current_page
+
+    try:
+        if current_page is None:
+            CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
+            return "zeuz_failed"
+
+        wait_download = 20
+        target_path = ""
+        click_dataset = []
+        for left, mid, right in data_set:
+            left_c = _compact(left)
+            mid_l = mid.strip().lower()
+            if left_c == "waitfordownload":
+                wait_download = float(right.strip())
+            elif left_c in ("folderpath", "directory", "filepath", "file", "folder") and mid_l == "optional parameter":
+                target_path = CommonUtil.path_parser(right.strip())
+            elif left_c == "automatefirefoxsavewindow":
+                continue
+            else:
+                click_dataset.append((left, mid, right))
+
+        locator = await PlaywrightLocator.Get_Element(click_dataset, current_page, frame_locator=_get_frame_locator())
+        if locator == "zeuz_failed":
+            CommonUtil.ExecLog(sModuleInfo, "Unable to locate your element with given data.", 3)
+            return "zeuz_failed"
+
+        CommonUtil.ExecLog(sModuleInfo, f"Download started. Will wait max {wait_download} seconds...", 1)
+        async with current_page.expect_download(timeout=int(wait_download * 1000)) as download_info:
+            await locator.click()
+        download = await download_info.value
+
+        if target_path:
+            parsed_path = Path(target_path)
+            if parsed_path.suffix:
+                parsed_path.parent.mkdir(parents=True, exist_ok=True)
+                save_path = parsed_path
+            else:
+                parsed_path.mkdir(parents=True, exist_ok=True)
+                save_path = parsed_path / download.suggested_filename
+        else:
+            save_path = Path(_download_folder()) / download.suggested_filename
+        await download.save_as(str(save_path))
+        CommonUtil.ExecLog(sModuleInfo, f"File downloaded to '{save_path}'", 1)
+        return "passed"
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())
+
+
 #########################
 #                       #
 #    Text Input         #
@@ -1521,8 +1670,13 @@ async def Keystroke_For_Element(step_data):
         key_map = {
             "CTRL": "Control",
             "CONTROL": "Control",
+            "CMD": "Meta",
+            "COMMAND": "Meta",
             "ALT": "Alt",
             "SHIFT": "Shift",
+            "PLUS": "+",
+            "MINUS": "-",
+            "DASH": "-",
             "ENTER": "Enter",
             "RETURN": "Enter",
             "TAB": "Tab",
@@ -1542,6 +1696,39 @@ async def Keystroke_For_Element(step_data):
         }
 
         if keystroke_type == "keys":
+            normalized_keystroke = keystroke_value.replace(" ", "").replace("_", "").lower()
+            if normalized_keystroke in ("ctrl+v", "control+v", "ctrlv", "controlv", "cmd+v", "cmdv", "command+v", "commandv"):
+                try:
+                    import pyperclip
+
+                    paste_text = pyperclip.paste()
+                    if has_element:
+                        locator = await PlaywrightLocator.Get_Element(step_data, current_page, frame_locator=_get_frame_locator())
+                        if locator == "zeuz_failed":
+                            CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
+                            return "zeuz_failed"
+                        await locator.evaluate("""(el, text) => {
+                            el.focus();
+                            const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+                            if (setter) setter.call(el, text); else el.value = text;
+                            el.dispatchEvent(new Event('input', { bubbles: true }));
+                            el.dispatchEvent(new Event('change', { bubbles: true }));
+                        }""", paste_text)
+                    else:
+                        await current_page.evaluate("""text => {
+                            const el = document.activeElement;
+                            if (el && 'value' in el) {
+                                const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+                                if (setter) setter.call(el, text); else el.value = text;
+                                el.dispatchEvent(new Event('input', { bubbles: true }));
+                                el.dispatchEvent(new Event('change', { bubbles: true }));
+                            }
+                        }""", paste_text)
+                    CommonUtil.ExecLog(sModuleInfo, "Paste successfully executed via JavaScript with events", 1)
+                    return "passed"
+                except Exception:
+                    CommonUtil.ExecLog(sModuleInfo, "JavaScript paste execution failed. Trying keypress.", 2)
+
             # Convert key names
             key = keystroke_value.upper()
             if "+" in key:
@@ -1632,7 +1819,6 @@ async def Validate_Text(step_data):
         expected_text = ""
         partial_match = False
         case_insensitive = False
-        timeout = None
 
         for left, mid, right in step_data:
             left_l = left.strip().lower()
@@ -1650,29 +1836,33 @@ async def Validate_Text(step_data):
                 expected_text = right_v
 
             elif mid_l == "optional parameter":
-                if left_l == "timeout":
-                    timeout = int(float(right_v) * 1000)
+                if left_l == "ignore case":
+                    case_insensitive = _truthy(right_v)
 
         locator = await PlaywrightLocator.Get_Element(step_data, current_page, frame_locator=_get_frame_locator())
         if locator == "zeuz_failed":
             CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
             return "zeuz_failed"
 
-        # Get actual text
-        actual_text = await locator.text_content() or ""
+        # Get visible text, matching Selenium Element.text behavior more closely.
+        try:
+            actual_text = await locator.inner_text() or ""
+        except Exception:
+            actual_text = await locator.text_content() or ""
+        actual_lines = [line for line in actual_text.split("\n") if line != ""]
 
         # Compare
         match = False
         if case_insensitive:
             if partial_match:
-                match = expected_text.lower() in actual_text.lower()
+                match = any(expected_text.lower() in line.lower() for line in actual_lines)
             else:
-                match = expected_text.lower() == actual_text.lower()
+                match = expected_text.lower() in [line.lower() for line in actual_lines]
         else:
             if partial_match:
-                match = expected_text in actual_text
+                match = any(expected_text in line for line in actual_lines)
             else:
-                match = expected_text == actual_text
+                match = expected_text in actual_lines
 
         if match:
             CommonUtil.ExecLog(sModuleInfo, f"Text validation passed: '{expected_text}'", 1)
@@ -1680,7 +1870,7 @@ async def Validate_Text(step_data):
         else:
             CommonUtil.ExecLog(
                 sModuleInfo,
-                f"Text validation failed.\nExpected: '{expected_text}'\nActual: '{actual_text}'",
+                f"Text validation failed.\nExpected: '{expected_text}'\nActual: '{actual_lines}'",
                 3
             )
             return "zeuz_failed"
@@ -1853,7 +2043,7 @@ async def Save_Attribute(step_data):
         # Get attribute value based on name
         attr_lower = attribute_name.lower()
         if attr_lower == "text":
-            value = await locator.text_content()
+            value = await locator.inner_text()
         elif attr_lower == "tag":
             value = (await locator.evaluate("el => el.tagName") or "").lower()
         elif attr_lower == "innertext":
@@ -1911,35 +2101,18 @@ async def get_element_info(step_data):
             CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
             return "zeuz_failed"
 
-        save_variable = None
-        for left, mid, right in step_data:
-            if mid.strip().lower() == "save parameter":
-                save_variable = left.strip()
+        save_variable = _save_variable_from_action_or_save_parameter(step_data, "get element info")
 
         locator = await PlaywrightLocator.Get_Element(step_data, current_page, frame_locator=_get_frame_locator())
         if locator == "zeuz_failed":
             CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
             return "zeuz_failed"
 
-        # Gather element info
+        box = await locator.bounding_box()
         info = {
-            "tag_name": await locator.evaluate("el => el.tagName"),
-            "text": await locator.text_content(),
-            "inner_html": await locator.inner_html(),
-            "visible": await locator.is_visible(),
-            "enabled": await locator.is_enabled(),
-            "bounding_box": await locator.bounding_box(),
+            "size": {"width": box["width"], "height": box["height"]} if box else {},
+            "location": {"x": box["x"], "y": box["y"]} if box else {},
         }
-
-        # Get all attributes
-        attributes = await locator.evaluate("""el => {
-            const attrs = {};
-            for (const attr of el.attributes) {
-                attrs[attr.name] = attr.value;
-            }
-            return attrs;
-        }""")
-        info["attributes"] = attributes
 
         if save_variable:
             sr.Set_Shared_Variables(save_variable, info)
@@ -2034,10 +2207,7 @@ def Get_Current_URL(step_data):
             CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
             return "zeuz_failed"
 
-        save_variable = None
-        for left, mid, right in step_data:
-            if mid.strip().lower() == "save parameter":
-                save_variable = left.strip()
+        save_variable = _save_variable_from_action_or_save_parameter(step_data, "get current url")
 
         url = current_page.url
 
@@ -2088,11 +2258,15 @@ async def Scroll(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "input parameter":
+            if _is_action_mid(mid_l) and left_l == "scroll":
+                direction = right_v.lower()
+            elif mid_l == "input parameter":
                 if left_l == "direction":
                     direction = right_v.lower()
                 elif left_l in ("pixel", "pixels", "amount"):
                     pixels = int(right_v)
+            elif left_l in ("pixel", "pixels", "amount"):
+                pixels = int(right_v)
 
         # Calculate delta
         delta_x = 0
@@ -2107,7 +2281,14 @@ async def Scroll(step_data):
         elif direction == "left":
             delta_x = -pixels
 
-        await current_page.mouse.wheel(delta_x, delta_y)
+        if _has_element_rows(step_data):
+            locator = await PlaywrightLocator.Get_Element(step_data, current_page, frame_locator=_get_frame_locator())
+            if locator == "zeuz_failed":
+                CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
+                return "zeuz_failed"
+            await locator.evaluate("(el, offset) => el.scrollBy(offset.x, offset.y)", {"x": delta_x, "y": delta_y})
+        else:
+            await current_page.mouse.wheel(delta_x, delta_y)
         CommonUtil.ExecLog(sModuleInfo, f"Scrolled {direction} by {pixels}px", 1)
         return "passed"
 
@@ -2154,7 +2335,7 @@ async def scroll_to_element(step_data):
 
         method = "js"
         align_to_top = "true"
-        additional_scroll = 0.0
+        additional_scroll = 0.1
         direction = ""
 
         for left, mid, right in step_data:
@@ -2173,7 +2354,10 @@ async def scroll_to_element(step_data):
                     try:
                         additional_scroll = float(right_v)
                     except ValueError:
-                        additional_scroll = 0.0
+                        additional_scroll = 0.1
+                    direction_part = left_l.replace("additional scroll", "").strip()
+                    if direction_part in ("up", "down", "left", "right"):
+                        direction = direction_part
 
         locator = await PlaywrightLocator.Get_Element(
             step_data, current_page, frame_locator=_get_frame_locator()
@@ -2605,7 +2789,6 @@ async def save_attribute_values_in_list(step_data):
                 if _is_session_step_row(left, mid):
                     continue
                 left_l = left.strip().lower()
-                left_key = left_l.replace(" ", "").replace("_", "")
                 right = right.strip()
                 if _is_target_parameter_mid(mid):
                     if spec_index >= 0 and _target_param_continues_previous_target(right):
@@ -2841,12 +3024,20 @@ def _parse_multiple_check_targets(target_parameter_value):
 
 async def _toggle_checkbox_target(locator, action, use_js, target_label):
     """Check or uncheck one target; logs and swallows per-target failures like Selenium."""
-    if action == "check" and await locator.is_checked():
-        CommonUtil.ExecLog("", f"{target_label} is already checked so skipped it", 1)
-        return
-    if action == "uncheck" and not await locator.is_checked():
-        CommonUtil.ExecLog("", f"{target_label} is already unchecked so skipped it", 1)
-        return
+    try:
+        checked = await locator.is_checked()
+    except Exception:
+        try:
+            checked = await locator.evaluate("el => Boolean(el.checked || el.getAttribute('aria-checked') === 'true')")
+        except Exception:
+            checked = None
+    if checked is not None:
+        if action == "check" and checked:
+            CommonUtil.ExecLog("", f"{target_label} is already checked so skipped it", 1)
+            return
+        if action == "uncheck" and not checked:
+            CommonUtil.ExecLog("", f"{target_label} is already unchecked so skipped it", 1)
+            return
 
     via_js = use_js
     try:
@@ -3049,6 +3240,7 @@ async def Select_Deselect(step_data):
         select_type = "label"  # label, value, index
         select_value = None
         is_deselect = False
+        deselect_all = False
 
         for left, mid, right in step_data:
             left_l = left.strip().lower()
@@ -3058,6 +3250,8 @@ async def Select_Deselect(step_data):
             if "action" in mid_l:
                 if "deselect" in left_l:
                     is_deselect = True
+                    if "all" in left_l:
+                        deselect_all = True
 
                 if "by value" in left_l or "byvalue" in left_l:
                     select_type = "value"
@@ -3068,7 +3262,9 @@ async def Select_Deselect(step_data):
 
                 select_value = right_v
 
-        if not select_value:
+        if deselect_all:
+            select_value = ""
+        elif not select_value:
             CommonUtil.ExecLog(sModuleInfo, "No selection value provided", 3)
             return "zeuz_failed"
 
@@ -3080,21 +3276,24 @@ async def Select_Deselect(step_data):
         # Build selection option
         if select_type == "value":
             option = {"value": select_value}
-        elif select_type == "index":
+        elif select_type == "index" and select_value != "":
             option = {"index": int(select_value)}
         else:  # label
             option = {"label": select_value}
 
         if is_deselect:
             # Playwright doesn't have direct deselect, use JavaScript
-            await locator.evaluate(f"""el => {{
-                for (const opt of el.options) {{
-                    if (opt.{'value' if select_type == 'value' else 'text'} === '{select_value}') {{
+            await locator.evaluate("""(el, data) => {
+                for (const opt of el.options) {
+                    if (data.all ||
+                        (data.type === 'value' && opt.value === data.value) ||
+                        (data.type === 'label' && opt.text === data.value) ||
+                        (data.type === 'index' && opt.index === Number(data.value))) {
                         opt.selected = false;
-                    }}
-                }}
+                    }
+                }
                 el.dispatchEvent(new Event('change'));
-            }}""")
+            }""", {"all": deselect_all, "type": select_type, "value": select_value})
             CommonUtil.ExecLog(sModuleInfo, f"Deselected: {select_value}", 1)
         else:
             await locator.select_option(**option)
@@ -3155,19 +3354,100 @@ async def check_uncheck(step_data):
             CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
             return "zeuz_failed"
 
-        options = {}
-        if use_js:
-            options["force"] = True
-
-        if action == "check":
-            await locator.check(**options)
-            CommonUtil.ExecLog(sModuleInfo, "Checkbox checked", 1)
-        else:
-            await locator.uncheck(**options)
-            CommonUtil.ExecLog(sModuleInfo, "Checkbox unchecked", 1)
+        await _toggle_checkbox_target(locator, action, use_js, "The element")
 
         return "passed"
 
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())
+
+
+@logger
+async def check_uncheck_all(data_set):
+    """Check or uncheck all target elements under a parent element."""
+
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global current_page
+
+    try:
+        if current_page is None:
+            CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
+            return "zeuz_failed"
+
+        use_js = False
+        target = []
+        command = "check"
+        for left, mid, right in data_set:
+            left_l = left.lower().strip()
+            mid_l = mid.lower().strip()
+            if left_l == "use js":
+                use_js = _truthy(right)
+            elif mid_l == "target parameter":
+                target.append((left, "element parameter", right))
+            elif left_l == "check uncheck all":
+                command = "uncheck" if "uncheck" in right.lower() else "check"
+            elif left_l == "allow hidden":
+                target.append((left, "option", right))
+
+        parent = await PlaywrightLocator.Get_Element(data_set, current_page, frame_locator=_get_frame_locator())
+        if parent == "zeuz_failed":
+            CommonUtil.ExecLog(sModuleInfo, "Could not find the parent element", 3)
+            return "zeuz_failed"
+
+        all_elements = await PlaywrightLocator.Get_Element(target, current_page, return_all=True, parent_locator=parent)
+        if not all_elements or all_elements == "zeuz_failed":
+            CommonUtil.ExecLog(sModuleInfo, "No target was found", 3)
+            return "zeuz_failed"
+
+        for index, element in enumerate(all_elements, start=1):
+            suffix = "th"
+            if index == 1:
+                suffix = "st"
+            elif index == 2:
+                suffix = "nd"
+            elif index == 3:
+                suffix = "rd"
+            await _toggle_checkbox_target(element, command, use_js, f"{index}{suffix} target")
+
+        return "passed"
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())
+
+
+@logger
+async def slider_bar(data_set):
+    """Set a slider by clicking at a percentage across the element."""
+
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global current_page
+
+    try:
+        if current_page is None:
+            CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
+            return "zeuz_failed"
+
+        value = None
+        for left, mid, right in data_set:
+            if _is_action_mid(mid):
+                value = int(right.strip())
+        if value is None:
+            CommonUtil.ExecLog(sModuleInfo, "Slider value must be provided", 3)
+            return "zeuz_failed"
+
+        locator = await PlaywrightLocator.Get_Element(data_set, current_page, frame_locator=_get_frame_locator())
+        if locator == "zeuz_failed":
+            CommonUtil.ExecLog(sModuleInfo, "Could not find the element", 3)
+            return "zeuz_failed"
+
+        box = await locator.bounding_box()
+        if not box:
+            CommonUtil.ExecLog(sModuleInfo, "Could not compute slider size", 3)
+            return "zeuz_failed"
+        x = box["x"] + (value / 100) * box["width"]
+        y = box["y"] + box["height"] / 2
+        await current_page.mouse.click(x, y)
+        CommonUtil.ExecLog(sModuleInfo, f"Successfully set the slider to %{value}", 1)
+        return "passed"
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())
 
@@ -3341,6 +3621,7 @@ async def close_tab(step_data):
 
         tab_title = None
         tab_index = None
+        close_tabs = []
 
         for left, mid, right in step_data:
             left_l = left.strip().lower()
@@ -3352,10 +3633,30 @@ async def close_tab(step_data):
                     tab_title = right_v
                 elif left_l == "tab index":
                     tab_index = int(right_v)
+                elif left_l == "tabs":
+                    close_tabs = CommonUtil.parse_value_into_object(right_v)
 
         pages = context.pages
 
-        if tab_title:
+        if close_tabs:
+            for target in close_tabs:
+                pages = context.pages
+                if isinstance(target, int):
+                    if -len(pages) <= target < len(pages):
+                        await pages[target].close()
+                    else:
+                        CommonUtil.ExecLog(sModuleInfo, f"Invalid tab index: {target}", 3)
+                        return "zeuz_failed"
+                else:
+                    target_l = str(target).lower()
+                    for page in pages:
+                        if target_l in (await page.title()).lower():
+                            await page.close()
+                            break
+                    else:
+                        CommonUtil.ExecLog(sModuleInfo, f"Tab not found: {target}", 3)
+                        return "zeuz_failed"
+        elif tab_title:
             for page in pages:
                 if tab_title.lower() in (await page.title()).lower():
                     await page.close()
@@ -3374,13 +3675,19 @@ async def close_tab(step_data):
         else:
             # Close current tab
             if current_page:
+                current_index = pages.index(current_page) if current_page in pages else len(pages) - 1
                 await current_page.close()
                 CommonUtil.ExecLog(sModuleInfo, "Closed current tab", 1)
 
         # Switch to remaining tab if available
         pages = context.pages
         if pages:
-            current_page = pages[-1]
+            if 'current_index' in locals() and current_index > 0 and current_index - 1 < len(pages):
+                current_page = pages[current_index - 1]
+            elif 'current_index' in locals():
+                current_page = pages[0]
+            else:
+                current_page = pages[-1]
             sr.Set_Shared_Variables("playwright_page", current_page)
             if current_page_id:
                 sessions = get_browser_sessions()
@@ -3667,6 +3974,12 @@ async def Handle_Browser_Alert(step_data):
 
             if "action" in mid_l:
                 action = right_v.lower()
+                if action.startswith("get text") and "=" in action:
+                    save_variable = right_v.split("=", 1)[1].strip()
+                    action = "accept"
+                elif action.startswith("send text") and "=" in action:
+                    prompt_text = right_v.split("=", 1)[1].strip()
+                    action = "accept"
             elif mid_l == "input parameter":
                 if left_l in ("prompt text", "text", "send text"):
                     prompt_text = right_v
@@ -3679,16 +3992,16 @@ async def Handle_Browser_Alert(step_data):
         try:
             dialog = await current_page.wait_for_event("dialog", timeout=timeout)
         except PlaywrightTimeoutError:
-            CommonUtil.ExecLog(sModuleInfo, "No alert appeared within timeout", 2)
-            return "passed"  # Not necessarily a failure
+            CommonUtil.ExecLog(sModuleInfo, "No alert appeared within timeout", 3)
+            return "zeuz_failed"
 
         message = dialog.message
-        if action in ("accept", "ok", "yes"):
+        if action in ("accept", "pass", "ok", "yes"):
             if prompt_text:
                 await dialog.accept(prompt_text)
             else:
                 await dialog.accept()
-        elif action in ("dismiss", "cancel", "no"):
+        elif action in ("dismiss", "reject", "fail", "cancel", "no"):
             await dialog.dismiss()
         else:
             await dialog.accept()
@@ -3899,7 +4212,11 @@ async def take_screenshot_playwright(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "element parameter":
+            if _is_action_mid(mid_l) and left_l == "take screenshot web":
+                if not _is_placeholder(right_v, "take screenshot web"):
+                    custom_path = time.strftime(right_v) + ".png"
+                    image_type = "png"
+            elif mid_l == "element parameter":
                 has_element = True
             elif mid_l == "optional parameter":
                 if left_l in ("fullscreen", "full page", "fullpage"):
@@ -3927,7 +4244,10 @@ async def take_screenshot_playwright(step_data):
                 screenshot_path = str(Path(screenshot_path).with_suffix(".jpg" if image_type == "jpeg" else ".png"))
         else:
             timestamp = time.strftime("%Y_%m_%d_%H-%M-%S")
-            screenshot_path = f"screenshot_{timestamp}.{'jpg' if image_type == 'jpeg' else 'png'}"
+            screenshot_path = str(Path(_screenshot_folder()) / f"screenshot_{timestamp}.{'jpg' if image_type == 'jpeg' else 'png'}")
+
+        if not Path(screenshot_path).is_absolute():
+            screenshot_path = str(Path(_screenshot_folder()) / screenshot_path)
 
         screenshot_options = {"path": screenshot_path, "type": image_type}
         if image_type == "jpeg":
@@ -3946,6 +4266,7 @@ async def take_screenshot_playwright(step_data):
 
         if save_variable:
             sr.Set_Shared_Variables(save_variable, screenshot_path)
+        sr.Set_Shared_Variables("zeuz_screenshot", Path(screenshot_path).name)
 
         CommonUtil.ExecLog(sModuleInfo, f"Screenshot saved: {screenshot_path}", 1)
         return "passed"
@@ -3996,14 +4317,14 @@ async def execute_javascript(step_data):
 
             if _is_session_step_row(left, mid):
                 continue
-            if mid_l in ("playwright action", "selenium action"):
-                continue
-            if "javascript" in left_l:
+            if "javascript" in left_l or (_is_action_mid(mid_l) and left_l == "execute javascript"):
                 js_code = right_v
             elif _is_element_parameter_mid(mid):
                 has_element = True
             elif mid_l == "save parameter":
                 save_variable = left.strip()
+            elif mid_l == "optional parameter" and left_l == "variable":
+                save_variable = right_v
 
         if not js_code:
             CommonUtil.ExecLog(sModuleInfo, "No JavaScript code provided", 3)
@@ -4015,8 +4336,14 @@ async def execute_javascript(step_data):
             if locator == "zeuz_failed":
                 CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
                 return "zeuz_failed"
-            result = await locator.evaluate(js_code)
+            if "$elem" in js_code:
+                element_script = js_code.replace("$elem", "el")
+                result = await locator.evaluate(f"el => {{ {element_script} }}")
+            else:
+                result = await locator.evaluate(js_code)
         else:
+            if js_code.strip().startswith("return "):
+                js_code = f"() => {{ {js_code} }}"
             result = await current_page.evaluate(js_code)
 
         if save_variable:
@@ -4063,7 +4390,9 @@ async def upload_file(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "input parameter":
+            if _is_action_mid(mid_l) and left_l == "upload file" and not _is_placeholder(right_v, "upload file"):
+                file_path = right_v
+            elif mid_l == "input parameter":
                 if left_l in ("file path", "filepath", "file", "path"):
                     file_path = right_v
 
@@ -4090,6 +4419,81 @@ async def upload_file(step_data):
         CommonUtil.ExecLog(sModuleInfo, f"File uploaded: {file_path}", 1)
         return "passed"
 
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())
+
+
+@logger
+async def copy_image_into_browser(data_set):
+    """Copy a PNG/SVG image into the browser clipboard."""
+
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global current_page, context
+
+    try:
+        if current_page is None:
+            CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
+            return "zeuz_failed"
+
+        image_path = ""
+        variable_name = ""
+        for left, mid, right in data_set:
+            left_c = _compact(left)
+            right_v = right.strip()
+            if left_c == "imagefile":
+                image_path = right_v if os.path.exists(right_v) else CommonUtil.path_parser(right_v)
+            elif left_c == "imagevariable":
+                if os.path.exists(right_v):
+                    image_path = right_v
+                else:
+                    variable_name = right_v
+
+        if not image_path and variable_name:
+            image_path = sr.Get_Shared_Variables(variable_name)
+        if not image_path:
+            CommonUtil.ExecLog(sModuleInfo, "Must provide either 'image file' or 'image variable'", 3)
+            return "zeuz_failed"
+        if not os.path.exists(image_path):
+            CommonUtil.ExecLog(sModuleInfo, f"Image file not found: {image_path}", 3)
+            return "zeuz_failed"
+
+        image_l = image_path.lower()
+        if image_l.endswith(".svg"):
+            mime_type = "image/svg+xml"
+        elif image_l.endswith(".png"):
+            mime_type = "image/png"
+        else:
+            CommonUtil.ExecLog(sModuleInfo, "Unsupported file format. You can copy only PNG or SVG image.", 2)
+            return "zeuz_failed"
+
+        if context:
+            try:
+                parsed = urlparse(current_page.url)
+                origin = f"{parsed.scheme}://{parsed.netloc}" if parsed.scheme and parsed.netloc else None
+                await context.grant_permissions(["clipboard-read", "clipboard-write"], origin=origin)
+            except Exception:
+                pass
+
+        image_b64 = base64.b64encode(Path(image_path).read_bytes()).decode("utf-8")
+        success = await current_page.evaluate("""async ({ imageB64, mimeType }) => {
+            const byteCharacters = atob(imageB64);
+            const byteArrays = [];
+            for (let offset = 0; offset < byteCharacters.length; offset += 512) {
+                const slice = byteCharacters.slice(offset, offset + 512);
+                const byteNumbers = new Array(slice.length);
+                for (let i = 0; i < slice.length; i++) byteNumbers[i] = slice.charCodeAt(i);
+                byteArrays.push(new Uint8Array(byteNumbers));
+            }
+            const blob = new Blob(byteArrays, { type: mimeType });
+            window.focus();
+            await navigator.clipboard.write([new ClipboardItem({ [mimeType]: blob })]);
+            return true;
+        }""", {"imageB64": image_b64, "mimeType": mime_type})
+        if success:
+            CommonUtil.ExecLog(sModuleInfo, f"Image copied to clipboard: {image_path}", 1)
+            return "passed"
+        CommonUtil.ExecLog(sModuleInfo, f"Failed to copy image to clipboard: {image_path}", 3)
+        return "zeuz_failed"
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())
 
@@ -4127,7 +4531,7 @@ async def resize_window(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "input parameter":
+            if mid_l in ("input parameter", "element parameter"):
                 if left_l == "width":
                     # Handle percentage
                     if "%" in right_v:
@@ -4354,6 +4758,120 @@ async def Stop_Tracing(step_data):
 
 
 @logger
+async def capture_network_log(step_data):
+    """Capture request/response metadata and save filtered network logs."""
+
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global current_page, current_page_id, network_log_details
+
+    def parse_status_codes(code_str):
+        result = []
+        for part in code_str.split(","):
+            part = part.strip()
+            if "-" in part:
+                start, end = map(int, part.split("-"))
+                result.extend(range(start, end + 1))
+            elif part:
+                result.append(int(part))
+        return result
+
+    try:
+        if current_page is None:
+            CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
+            return "zeuz_failed"
+
+        params = {
+            "variable_name": None,
+            "mode": None,
+            "filter_domains": [],
+            "status_filter": [],
+            "method_filter": [],
+            "include_body": False,
+        }
+        for left, mid, right in step_data:
+            left_l = left.lower().strip()
+            if left_l == "capture network log":
+                params["mode"] = right.lower().strip()
+            elif left_l == "save":
+                params["variable_name"] = right.strip()
+            elif left_l == "filter domain":
+                params["filter_domains"] = [d.strip() for d in right.split(",")]
+            elif left_l == "include status code":
+                params["status_filter"] = parse_status_codes(right.strip())
+            elif left_l == "include request method":
+                params["method_filter"] = [m.strip().upper() for m in right.split(",")]
+            elif left_l == "include response body":
+                params["include_body"] = _truthy(right)
+
+        session_key = current_page_id or "default"
+        if params["mode"] == "start":
+            requests = {}
+            events = []
+
+            async def on_request(request):
+                requests[id(request)] = request
+
+            async def on_response(response):
+                request = response.request
+                entry = {
+                    "url": response.url,
+                    "status": response.status,
+                    "method": request.method,
+                    "mimeType": response.headers.get("content-type", ""),
+                    "type": request.resource_type,
+                    "timestamp": time.time(),
+                }
+                if params["include_body"]:
+                    try:
+                        entry["body"] = await response.text()
+                    except Exception:
+                        entry["body"] = "Unavailable"
+                events.append(entry)
+
+            current_page.on("request", on_request)
+            current_page.on("response", on_response)
+            network_log_details[session_key] = {"events": events, "on_request": on_request, "on_response": on_response}
+            CommonUtil.ExecLog(sModuleInfo, "Started collecting network logs...", 1)
+            return "passed"
+
+        if params["mode"] == "stop":
+            state = network_log_details.pop(session_key, {"events": []})
+            try:
+                current_page.remove_listener("request", state.get("on_request"))
+                current_page.remove_listener("response", state.get("on_response"))
+            except Exception:
+                pass
+
+            excluded_ext = (".js", ".css", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".woff", ".woff2", ".ttf", ".eot", ".webp", ".map", ".txt")
+            excluded_mime = ("image/", "font/", "text/css", "application/javascript", "text/javascript", "application/font-", "application/x-font-")
+            api_logs = []
+            for entry in state.get("events", []):
+                url = entry.get("url", "")
+                mime_type = entry.get("mimeType", "")
+                if any(url.endswith(ext) for ext in excluded_ext) or any(mime_type.startswith(prefix) for prefix in excluded_mime):
+                    continue
+                if params["filter_domains"]:
+                    domain = urlparse(url).netloc
+                    if not any(d in domain for d in params["filter_domains"]):
+                        continue
+                if params["method_filter"] and entry.get("method", "").upper() not in params["method_filter"]:
+                    continue
+                if params["status_filter"] and entry.get("status") not in params["status_filter"]:
+                    continue
+                api_logs.append(entry)
+
+            if params["variable_name"]:
+                sr.Set_Shared_Variables(params["variable_name"], api_logs)
+                CommonUtil.ExecLog(sModuleInfo, f"Saved {len(api_logs)} network events to '{params['variable_name']}'", 1)
+            return "passed"
+
+        CommonUtil.ExecLog(sModuleInfo, "Mode must be start or stop", 3)
+        return "zeuz_failed"
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info(), None, "Could not collect network logs")
+
+
+@logger
 async def Intercept_Network(step_data):
     """
     Set up network request interception.
@@ -4449,7 +4967,9 @@ async def Extract_Table_Data(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "save parameter":
+            if _is_action_mid(mid_l) and left_l == "extract table data" and not _is_placeholder(right_v, "extract table data"):
+                save_variable = right_v
+            elif mid_l == "save parameter":
                 save_variable = left.strip()
             elif mid_l == "optional parameter":
                 if left_l == "row":
@@ -4478,6 +4998,17 @@ async def Extract_Table_Data(step_data):
             });
             return data;
         }""")
+
+        if row_filter and "," not in row_filter and "-" not in row_filter:
+            try:
+                table_data = [table_data[int(row_filter.replace(" ", ""))]]
+            except Exception:
+                table_data = eval("table_data[%s]" % row_filter.replace(" ", ""))
+        if col_filter and "," not in col_filter and "-" not in col_filter:
+            try:
+                table_data = [[row[int(col_filter.replace(" ", ""))]] for row in table_data]
+            except Exception:
+                table_data = [eval("row[%s]" % col_filter.replace(" ", "")) for row in table_data]
 
         if save_variable:
             sr.Set_Shared_Variables(save_variable, table_data)

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -29,6 +29,7 @@ import time
 import base64
 from pathlib import Path
 from urllib.parse import urlparse
+import requests
 
 from playwright.async_api import (
     async_playwright,
@@ -41,6 +42,7 @@ from playwright.async_api import (
 
 from Framework.Utilities import CommonUtil, ConfigModule
 from Framework.Utilities.decorators import logger
+from settings import ZEUZ_NODE_DOWNLOADS_DIR
 from Framework.Built_In_Automation.Shared_Resources import (
     BuiltInFunctionSharedResources as sr,
 )
@@ -144,6 +146,34 @@ def _save_current_playwright_frame(frame_locator):
             sr.Set_Shared_Variables("browser_sessions", sessions)
 
 
+def _get_installed_cft_chromedriver(browser_version):
+    system = platform.system().lower()
+    arch = platform.machine().lower()
+
+    if system == "windows":
+        platform_key = "win64" if arch in ("amd64", "x86_64") else "win32"
+        executable = "chromedriver.exe"
+    elif system == "darwin":
+        platform_key = "mac-arm64" if arch == "arm64" else "mac-x64"
+        executable = "chromedriver"
+    elif system == "linux":
+        platform_key = "linux64"
+        executable = "chromedriver"
+    else:
+        return None
+
+    driver_path = (
+        ZEUZ_NODE_DOWNLOADS_DIR
+        / "chrome_for_testing"
+        / "versions"
+        / browser_version
+        / "driver"
+        / f"chromedriver-{platform_key}"
+        / executable
+    )
+    return str(driver_path) if driver_path.exists() else None
+
+
 async def _activate_browser_session_for_action(step_data, function_name=None):
     """Select the requested browser session before running Playwright actions."""
 
@@ -178,11 +208,45 @@ def connect_selenium_to_playwright(port=9222):
     try:
         from selenium import webdriver
         from selenium.webdriver.chrome.options import Options
+        from selenium.webdriver.chrome.service import Service
+        from webdriver_manager.chrome import ChromeDriverManager
         
         options = Options()
         options.add_experimental_option("debuggerAddress", f"127.0.0.1:{port}")
-        
-        driver = webdriver.Chrome(options=options)
+
+        service = None
+        try:
+            response = requests.get(f"http://127.0.0.1:{port}/json/version", timeout=5)
+            response.raise_for_status()
+            browser_version = (
+                response.json()
+                .get("Browser", "")
+                .split("/", 1)[-1]
+                .strip()
+            )
+            if browser_version:
+                driver_path = _get_installed_cft_chromedriver(browser_version)
+                if not driver_path:
+                    driver_path = ChromeDriverManager(
+                        driver_version=browser_version
+                    ).install()
+                service = Service(executable_path=driver_path)
+                CommonUtil.ExecLog(
+                    "connect_selenium_to_playwright",
+                    f"Using ChromeDriver matching browser version {browser_version}",
+                    1,
+                )
+        except Exception:
+            CommonUtil.ExecLog(
+                "connect_selenium_to_playwright",
+                "Could not resolve matching ChromeDriver for Playwright browser; falling back to Selenium Manager",
+                2,
+            )
+
+        if service:
+            driver = webdriver.Chrome(service=service, options=options)
+        else:
+            driver = webdriver.Chrome(options=options)
         
         from Framework.Built_In_Automation.Web.Selenium import BuiltInFunctions as SeleniumBuiltInFunctions
         SeleniumBuiltInFunctions.selenium_driver = driver

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -24,6 +24,7 @@ import asyncio
 import sys
 import os
 import inspect
+import platform
 import time
 import re
 from pathlib import Path
@@ -471,17 +472,186 @@ async def Open_Browser(step_data):
 
 
 @logger
+async def Open_Electron_App(step_data):
+    """
+    Launch an Electron desktop app via Playwright's Electron API.
+
+    Example - Basic (per-OS binary paths, like Selenium):
+        Field               Sub Field           Value
+        windows             input parameter     C:\\Path\\To\\MyApp.exe
+        mac                 input parameter     /Applications/MyApp.app/Contents/MacOS/MyApp
+        linux               input parameter     /opt/myapp/myapp
+        open electron app   playwright action   open electron app
+
+    Example - With optional parameters:
+        Field               Sub Field           Value
+        mac                 input parameter     /Applications/MyApp.app/Contents/MacOS/MyApp
+        session             optional parameter  electron_1
+        add argument        optional parameter  --no-sandbox
+        cwd                 optional parameter  /tmp/working_dir
+        timeout             optional parameter  30
+        open electron app   playwright action   open electron app
+
+    Notes:
+        - Only the path matching the current OS is used; other rows are ignored.
+        - The first Electron BrowserWindow becomes the active page, so subsequent
+          element / click / text actions work the same as in a normal browser session.
+    """
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global playwright_instance, browser, context, current_page
+    global current_page_id, playwright_details
+
+    try:
+        desktop_app_path = ""
+        driver_id = ""
+        args = []
+        cwd = None
+        env_vars = {}
+        timeout = None
+        record_video = False
+        video_dir = None
+
+        for left, mid, right in step_data:
+            left_compact = left.replace(" ", "").replace("_", "").replace("-", "").lower()
+            mid_l = mid.strip().lower()
+            right_v = right.strip()
+
+            if "windows" in left_compact and platform.system() == "Windows":
+                desktop_app_path = right_v
+            elif "mac" in left_compact and platform.system() == "Darwin":
+                desktop_app_path = right_v
+            elif "linux" in left_compact and platform.system() == "Linux":
+                desktop_app_path = right_v
+            elif left_compact == "driverid":
+                driver_id = right_v
+            elif left_compact == "session" and mid_l == "optional parameter":
+                driver_id = right_v
+            elif mid_l == "optional parameter":
+                if left_compact in ("addargument", "arg", "argument"):
+                    args.append(right_v)
+                elif left_compact == "cwd":
+                    cwd = right_v
+                elif left_compact == "env":
+                    # Format: KEY=VALUE
+                    if "=" in right_v:
+                        k, v = right_v.split("=", 1)
+                        env_vars[k.strip()] = v.strip()
+                elif left_compact == "timeout":
+                    try:
+                        timeout = int(float(right_v) * 1000)
+                    except ValueError:
+                        pass
+                elif left_compact == "recordvideo":
+                    record_video = right_v.lower() in ("true", "yes", "1")
+                elif left_compact == "videodir":
+                    video_dir = right_v
+
+        if not desktop_app_path:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"You did not provide an Electron app path for {platform.system()} OS",
+                3,
+            )
+            return "zeuz_failed"
+
+        if not driver_id:
+            driver_id = "default"
+
+        desktop_app_path = CommonUtil.path_parser(desktop_app_path)
+
+        # Reserve a debug port for the session even though Playwright drives Electron via CDP automatically.
+        electron_port = get_debug_port(driver_id or "electron", start=9230, stop=9320)
+
+        launch_options = {"executable_path": desktop_app_path}
+        if args:
+            launch_options["args"] = args
+        if cwd:
+            launch_options["cwd"] = cwd
+        if env_vars:
+            launch_options["env"] = env_vars
+        if timeout:
+            launch_options["timeout"] = timeout
+        if record_video:
+            launch_options["record_video_dir"] = video_dir or "videos/"
+
+        playwright_instance = await async_playwright().start()
+        try:
+            electron_app = await playwright_instance._electron.launch(**launch_options)
+        except Exception:
+            return CommonUtil.Exception_Handler(sys.exc_info())
+
+        try:
+            current_page = await electron_app.first_window()
+        except Exception:
+            # Some Electron apps create no visible BrowserWindow at startup.
+            current_page = None
+
+        # In Electron there is no BrowserContext we own - bind the app object in its place so
+        # downstream session-aware code keeps working.
+        context = electron_app.context if hasattr(electron_app, "context") else None
+        browser = electron_app  # `browser` slot holds the launched app for teardown.
+        current_page_id = driver_id
+
+        playwright_details[driver_id] = {
+            "page": current_page,
+            "context": context,
+            "browser": electron_app,
+            "playwright": playwright_instance,
+            "remote-debugging-port": electron_port,
+        }
+
+        sr.Set_Shared_Variables("playwright_page", current_page)
+        sr.Set_Shared_Variables("playwright_context", context)
+        sr.Set_Shared_Variables("playwright_browser", electron_app)
+        sr.Set_Shared_Variables("active_web_driver_type", "playwright")
+        if timeout:
+            sr.Set_Shared_Variables("element_wait", timeout / 1000)
+        CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
+
+        create_browser_session(
+            session_name=driver_id,
+            playwright_page=current_page,
+            playwright_browser=electron_app,
+            playwright_context=context,
+            playwright_frame=None,
+            playwright_instance=playwright_instance,
+            remote_debugging_port=electron_port,
+        )
+
+        CommonUtil.ExecLog(sModuleInfo, "Started Electron App", 1)
+        return "passed"
+
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())
+
+
+@logger
 async def Go_To_Link(step_data):
     """
-    Navigate to a URL.
+    Navigate to a URL (and open browser if not already open).
 
-    Example:
-        Field               Sub Field           Value
-        go to link          input parameter     https://example.com
-        wait until          optional parameter  networkidle
-        go to link          playwright action   go to link
+    Example 1 - Basic:
+        Field                       Sub Field           Value
+        go to link                  input parameter     https://example.com
+        go to link                  playwright action   go to link
 
-    wait until options: load, domcontentloaded, networkidle, commit
+    Example 2 - Selenium-compatible options:
+        Field                       Sub Field           Value
+        go to link                  input parameter     https://example.com
+        wait time to appear element optional parameter  20
+        wait time to page load      optional parameter  60
+        resolution                  optional parameter  1920,1080
+        wait until                  optional parameter  networkidle
+        go to link                  playwright action   go to link
+
+    Options:
+        - wait until (load | domcontentloaded | networkidle | commit)
+        - timeout / wait time to page load: page load timeout in seconds
+        - wait for element / wait time to appear element: element wait timeout
+          (seconds) saved to the "element_wait" shared variable so subsequent
+          element lookups use it
+        - resolution: WIDTHxHEIGHT or WIDTH,HEIGHT (applied to the current page)
+        - session: reuse or create a named browser session
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global current_page
@@ -493,31 +663,30 @@ async def Go_To_Link(step_data):
             left_l = left.strip().lower()
             mid_l = mid.strip().lower()
             right_v = right.strip()
-            
+
             if mid_l == "optional parameter" and left_l == "session":
                 session_name = right_v
                 break
-        
+
         # Check if session exists and use it
         if session_name:
             existing_session = get_browser_session(session_name)
-            
             if existing_session and await _ensure_playwright_session(session_name, existing_session) not in failed_tag_list:
                 CommonUtil.ExecLog(sModuleInfo, f"Using existing browser session: {session_name}", 1)
             else:
                 # Session doesn't exist, open new browser with session name
                 CommonUtil.ExecLog(sModuleInfo, f"Session '{session_name}' not found. Opening new browser.", 2)
-                
+
                 # Add session parameter to step_data for Open_Browser
                 step_data_with_session = step_data.copy()
                 if not any(left.strip().lower() == "session" and mid.strip().lower() == "optional parameter" for left, mid, right in step_data_with_session):
                     step_data_with_session.append(("session", "optional parameter", session_name))
-                
+
                 result = await Open_Browser(step_data_with_session)
                 if result == "zeuz_failed":
                     CommonUtil.ExecLog(sModuleInfo, "Failed to open browser for new session", 3)
                     return "zeuz_failed"
-        
+
         elif current_page is None:
             default_session = get_browser_session("default")
             if default_session and default_session.get("selenium_driver"):
@@ -535,42 +704,80 @@ async def Go_To_Link(step_data):
         url = None
         wait_until = "domcontentloaded"
         timeout = None
+        element_wait_sec = None
+        window_size_x = None
+        window_size_y = None
 
         for left, mid, right in step_data:
-            left_l = left.strip().lower()
+            left_raw = left.strip()
+            left_l = left_raw.lower()
+            left_compact = left_l.replace(" ", "").replace("_", "").replace("-", "")
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
             if left_l in ("go to link", "url", "link"):
-                    url = right_v
+                url = right_v
             elif mid_l == "optional parameter":
                 if left_l == "session":
-                    # Skip session parameter - already processed above
                     continue
-                elif left_l in ("wait until", "wait_until", "waituntil", "wait time"):
+                if left_l in ("wait until", "wait_until", "waituntil"):
                     wait_until = right_v.lower()
-                elif left_l == "timeout":
-                    timeout = int(float(right_v) * 1000)
+                elif left_compact in ("timeout", "waittimetopageload", "pageloadtimeout"):
+                    try:
+                        timeout = int(float(right_v) * 1000)
+                    except ValueError:
+                        pass
+                elif left_compact in ("waittimetoappearelement", "waitforelement", "elementwait"):
+                    try:
+                        element_wait_sec = float(right_v)
+                    except ValueError:
+                        pass
+                elif left_l == "resolution":
+                    try:
+                        parts = right_v.replace("x", ",").split(",")
+                        window_size_x = int(parts[0].strip())
+                        window_size_y = int(parts[1].strip())
+                    except (ValueError, IndexError):
+                        pass
 
         if not url:
             CommonUtil.ExecLog(sModuleInfo, "No URL provided", 3)
             return "zeuz_failed"
 
+        if element_wait_sec is not None:
+            sr.Set_Shared_Variables("element_wait", element_wait_sec)
+
+        if timeout:
+            try:
+                current_page.set_default_navigation_timeout(timeout)
+                current_page.set_default_timeout(timeout)
+            except Exception:
+                pass
+
+        if window_size_x and window_size_y:
+            try:
+                await current_page.set_viewport_size({"width": window_size_x, "height": window_size_y})
+            except Exception:
+                pass
+
         goto_options = {"wait_until": wait_until}
         if timeout:
             goto_options["timeout"] = timeout
 
-        await current_page.goto(url, **goto_options)
-        
+        try:
+            await current_page.goto(url, **goto_options)
+        except PlaywrightTimeoutError:
+            CommonUtil.ExecLog(sModuleInfo, "Maximum page load time reached. Loading and proceeding", 2)
+
         # Reset frame context when navigating to a new URL
         sr.Set_Shared_Variables("playwright_frame", None)
         _save_current_playwright_frame(None)
-        
-        CommonUtil.ExecLog(sModuleInfo, f"Navigated to: {url}", 1)
+
+        CommonUtil.ExecLog(sModuleInfo, f"Successfully opened your link: {url}", 1)
         return "passed"
 
     except Exception:
-        return CommonUtil.Exception_Handler(sys.exc_info())
+        return CommonUtil.Exception_Handler(sys.exc_info(), None, "failed to open your link")
 
 
 @logger
@@ -814,7 +1021,7 @@ async def Switch_Browser(step_data):
 #########################
 
 @logger
-async def Click_Element(step_data):
+async def Click_Element(step_data, retry=0):
     """
     Click an element.
 
@@ -823,19 +1030,24 @@ async def Click_Element(step_data):
         id                  element parameter   submit-btn
         click               playwright action   click
 
-    Example 2 - With options:
+    Example 2 - With JS click (forces click via JS .click()):
         Field               Sub Field           Value
         id                  element parameter   submit-btn
         use js              optional parameter  true
-        offset              optional parameter  10,5
         click               playwright action   click
 
-    Example 3 - Double click:
+    Example 3 - Click at offset (Selenium-compatible: percent from element center):
+        Field               Sub Field           Value
+        id                  element parameter   submit-btn
+        offset              optional parameter  20,30
+        click               playwright action   click
+
+    Example 4 - Double click:
         Field               Sub Field           Value
         id                  element parameter   item
         double click        playwright action   double click
 
-    Example 4 - Right click:
+    Example 5 - Right click:
         Field               Sub Field           Value
         id                  element parameter   item
         right click         playwright action   right click
@@ -846,14 +1058,13 @@ async def Click_Element(step_data):
     try:
         # Handle session parameter
         session_name, current_page, current_page_id, context, browser = await _handle_playwright_session(step_data)
-        
         if current_page is None:
             CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
             return "zeuz_failed"
 
         # Parse options
         use_js = False
-        offset = None
+        offset_value = ""
         double_click = False
         right_click = False
         click_count = 1
@@ -874,8 +1085,7 @@ async def Click_Element(step_data):
                 if left_l == "use js":
                     use_js = right_v.lower() in ("true", "yes", "1")
                 elif left_l == "offset":
-                    parts = right_v.split(",")
-                    offset = {"x": float(parts[0].strip()), "y": float(parts[1].strip())}
+                    offset_value = right_v
                 elif left_l == "click count":
                     click_count = int(right_v)
                 elif left_l == "modifier":
@@ -894,15 +1104,51 @@ async def Click_Element(step_data):
         # Get element
         locator = await PlaywrightLocator.Get_Element(step_data, current_page, frame_locator=_get_frame_locator())
         if locator == "zeuz_failed":
-            CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
+            CommonUtil.ExecLog(sModuleInfo, "Could not find element", 3)
             return "zeuz_failed"
+
+        # Click using offset (Selenium-compatible: percentage of half element size from center)
+        if offset_value:
+            try:
+                box = await locator.bounding_box()
+                if not box:
+                    CommonUtil.ExecLog(sModuleInfo, "Cannot determine element bounding box for offset click", 3)
+                    return "zeuz_failed"
+                parts = offset_value.replace(" ", "").split(",")
+                pct_x = float(parts[0])
+                pct_y = float(parts[1])
+                # Selenium-style: percent of half-size from center, anchored at top-left of element
+                offset_x = (box["width"] / 2.0) + (box["width"] / 2.0) * (pct_x / 100.0)
+                offset_y = (box["height"] / 2.0) + (box["height"] / 2.0) * (pct_y / 100.0)
+                click_options = {"position": {"x": offset_x, "y": offset_y}}
+                if modifiers:
+                    click_options["modifiers"] = modifiers
+                if delay:
+                    click_options["delay"] = delay
+                if timeout:
+                    click_options["timeout"] = timeout
+                if right_click:
+                    click_options["button"] = "right"
+                if double_click:
+                    await locator.dblclick(**click_options)
+                else:
+                    await locator.click(**click_options)
+                CommonUtil.ExecLog(sModuleInfo, "Click on location successful", 1)
+                return "passed"
+            except Exception:
+                return CommonUtil.Exception_Handler(sys.exc_info(), None, "Error clicking location")
+
+        # JS click - matches Selenium use_js behavior (true HTMLElement.click() via JS)
+        if use_js:
+            try:
+                await locator.evaluate("el => el.click()")
+                CommonUtil.ExecLog(sModuleInfo, "Successfully clicked the element via JS", 1)
+                return "passed"
+            except Exception:
+                return CommonUtil.Exception_Handler(sys.exc_info())
 
         # Build click options
         click_options = {}
-        if use_js:
-            click_options["force"] = True
-        if offset:
-            click_options["position"] = offset
         if modifiers:
             click_options["modifiers"] = modifiers
         if delay:
@@ -913,18 +1159,52 @@ async def Click_Element(step_data):
             click_options["click_count"] = click_count
 
         # Perform click
-        if double_click:
-            await locator.dblclick(**{k: v for k, v in click_options.items() if k != "click_count"})
-            CommonUtil.ExecLog(sModuleInfo, "Double click performed", 1)
-        elif right_click:
-            click_options["button"] = "right"
-            await locator.click(**click_options)
-            CommonUtil.ExecLog(sModuleInfo, "Right click performed", 1)
-        else:
-            await locator.click(**click_options)
-            CommonUtil.ExecLog(sModuleInfo, "Click performed", 1)
-
-        return "passed"
+        try:
+            if double_click:
+                await locator.dblclick(**{k: v for k, v in click_options.items() if k != "click_count"})
+                CommonUtil.ExecLog(sModuleInfo, "Double click performed", 1)
+            elif right_click:
+                click_options["button"] = "right"
+                await locator.click(**click_options)
+                CommonUtil.ExecLog(sModuleInfo, "Right click performed", 1)
+            else:
+                await locator.click(**click_options)
+                CommonUtil.ExecLog(sModuleInfo, "Successfully clicked the element", 1)
+            return "passed"
+        except PlaywrightTimeoutError:
+            # Click intercepted or element not actionable - fall back to JS click (matches Selenium behavior)
+            try:
+                await locator.evaluate("el => el.click()")
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    "Your element is overlapped with another sibling element. Clicked the element successfully by executing JavaScript",
+                    2,
+                )
+                return "passed"
+            except Exception:
+                return CommonUtil.Exception_Handler(sys.exc_info())
+        except PlaywrightError as e:
+            err_msg = str(e).lower()
+            # Stale element: retry up to 5 times with 1s delay
+            if ("stale" in err_msg or "detached" in err_msg) and retry < 5:
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    "Javascript of the element is not fully loaded. Trying again after 1 second delay",
+                    2,
+                )
+                await asyncio.sleep(1)
+                return await Click_Element(step_data, retry + 1)
+            # Try JS click fallback
+            try:
+                await locator.evaluate("el => el.click()")
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    "Click failed natively; clicked successfully via JavaScript",
+                    2,
+                )
+                return "passed"
+            except Exception:
+                return CommonUtil.Exception_Handler(sys.exc_info())
 
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())
@@ -1044,7 +1324,7 @@ async def Enter_Text_In_Text_Box(step_data):
         text                action              my_username
         text                playwright action   text
 
-    Example 2 - With options:
+    Example 2 - With options (Selenium-compatible):
         Field               Sub Field           Value
         id                  element parameter   username
         text                action              my_username
@@ -1059,7 +1339,6 @@ async def Enter_Text_In_Text_Box(step_data):
     try:
         # Handle session parameter
         session_name, current_page, current_page_id, context, browser = await _handle_playwright_session(step_data)
-        
         if current_page is None:
             CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
             return "zeuz_failed"
@@ -1092,38 +1371,78 @@ async def Enter_Text_In_Text_Box(step_data):
 
         locator = await PlaywrightLocator.Get_Element(step_data, current_page, frame_locator=_get_frame_locator())
         if locator == "zeuz_failed":
-            CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
+            CommonUtil.ExecLog(sModuleInfo, "Unable to locate your element with given data.", 3)
             return "zeuz_failed"
 
         # Enter text based on options
         if use_js:
-            # Use JavaScript to set value directly
-            await locator.evaluate(f"el => {{ el.value = `{text_value}`; }}")
-            # Trigger events
+            # JS mode mirrors Selenium: click, set value, dispatch input/change events, click again.
+            try:
+                await locator.evaluate("el => el.click()")
+            except Exception:
+                CommonUtil.ExecLog(sModuleInfo, "Entering text without clicking the element", 2)
+            # Use JS template-literal so embedded quotes/newlines are preserved (matches Selenium).
+            escaped = text_value.replace("\\", "\\\\").replace("`", "\\`").replace("${", "\\${")
+            await locator.evaluate(f"el => {{ el.value = `{escaped}`; }}")
             await locator.dispatch_event("input")
             await locator.dispatch_event("change")
-            CommonUtil.ExecLog(sModuleInfo, f"Text entered via JS: {text_value[:50]}{'...' if len(text_value) > 50 else ''}", 1)
-        elif clear:
-            # fill() clears and sets value - recommended approach
-            fill_options = {}
-            if timeout:
-                fill_options["timeout"] = timeout
-            await locator.fill(text_value, **fill_options)
-            CommonUtil.ExecLog(sModuleInfo, f"Text filled: {text_value[:50]}{'...' if len(text_value) > 50 else ''}", 1)
+            try:
+                await locator.evaluate("el => el.click()")
+            except Exception:
+                pass
+            CommonUtil.ExecLog(sModuleInfo, f"Successfully set the value of to text to: {text_value}", 1)
+            return "passed"
+
+        # Non-JS path: click first to focus (best-effort), clear if requested, then type/fill.
+        try:
+            await locator.click()
+        except Exception:
+            CommonUtil.ExecLog(sModuleInfo, "Entering text without clicking the element", 2)
+
+        if clear:
+            try:
+                # Select-all + delete pattern matches Selenium clear logic across platforms.
+                if sys.platform == "darwin":
+                    await locator.press("Meta+A")
+                else:
+                    await locator.press("Control+A")
+                await locator.press("Delete")
+            except Exception:
+                pass
+            try:
+                # fill() always clears first; also handles inputs where Select-All didn't apply.
+                fill_options = {}
+                if timeout:
+                    fill_options["timeout"] = timeout
+                if delay == 0:
+                    await locator.fill(text_value, **fill_options)
+                else:
+                    # Caller wants per-keystroke delay -> type after clearing.
+                    type_options = {"delay": int(delay * 1000)}
+                    if timeout:
+                        type_options["timeout"] = timeout
+                    await locator.type(text_value, **type_options)
+            except Exception:
+                return CommonUtil.Exception_Handler(sys.exc_info())
         else:
-            # type() appends to existing value
             type_options = {}
             if delay > 0:
                 type_options["delay"] = int(delay * 1000)
             if timeout:
                 type_options["timeout"] = timeout
             await locator.type(text_value, **type_options)
-            CommonUtil.ExecLog(sModuleInfo, f"Text typed: {text_value[:50]}{'...' if len(text_value) > 50 else ''}", 1)
 
+        # Some text fields become unclickable after entering text - best-effort click.
+        try:
+            await locator.click()
+        except Exception:
+            pass
+
+        CommonUtil.ExecLog(sModuleInfo, f"Successfully set the value of to text to: {text_value}", 1)
         return "passed"
 
     except Exception:
-        return CommonUtil.Exception_Handler(sys.exc_info())
+        return CommonUtil.Exception_Handler(sys.exc_info(), None, "Could not select/click your element.")
 
 
 @logger
@@ -1373,14 +1692,22 @@ async def Validate_Text(step_data):
 @logger
 async def if_element_exists(step_data):
     """
-    Check if an element exists on the page.
+    Check whether an element exists (true/false).
 
-    Example:
+    Selenium-compatible form (writes the result to a shared variable, always returns "passed"):
+        Field               Sub Field           Value
+        id                  element parameter   optional-element
+        if element exists   playwright action   true=my_flag
+
+        - If found: shared variable my_flag is set to "true"
+        - If not found: shared variable my_flag is set to "false"
+
+    Plain form (no save):
         Field               Sub Field           Value
         id                  element parameter   optional-element
         if element exists   playwright action   if element exists
 
-    Returns "passed" if element exists, "zeuz_failed" if not.
+        - Returns "passed" if found, "zeuz_failed" if not.
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global current_page
@@ -1390,35 +1717,59 @@ async def if_element_exists(step_data):
             CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
             return "zeuz_failed"
 
+        variable_name = ""
+        value = ""
         timeout = 1000  # Short timeout for existence check
+
         for left, mid, right in step_data:
             left_l = left.strip().lower()
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "optional parameter" and left_l == "timeout":
+            if "action" in mid_l and "=" in right_v:
+                try:
+                    value_part, var_part = right_v.split("=", 1)
+                    value = value_part.strip()
+                    variable_name = var_part.strip()
+                except ValueError:
+                    pass
+            elif mid_l == "optional parameter" and left_l == "timeout":
                 timeout = int(float(right_v) * 1000)
 
-        locator = await PlaywrightLocator.Get_Element(step_data, current_page, element_wait=timeout/1000, frame_locator=_get_frame_locator())
+        locator = await PlaywrightLocator.Get_Element(
+            step_data,
+            current_page,
+            element_wait=timeout / 1000,
+            frame_locator=_get_frame_locator(),
+        )
 
-        if locator == "zeuz_failed":
-            CommonUtil.ExecLog(sModuleInfo, "Element does not exist", 1)
-            return "zeuz_failed"
+        found = False
+        if locator != "zeuz_failed":
+            try:
+                if await locator.count() > 0:
+                    found = True
+            except Exception:
+                found = False
 
-        try:
-            count = await locator.count()
-            if count > 0:
-                CommonUtil.ExecLog(sModuleInfo, f"Element exists ({count} found)", 1)
-                return "passed"
-            else:
-                CommonUtil.ExecLog(sModuleInfo, "Element does not exist", 1)
-                return "zeuz_failed"
-        except Exception:
-            CommonUtil.ExecLog(sModuleInfo, "Element does not exist", 1)
-            return "zeuz_failed"
+        if variable_name:
+            # Selenium-compatible: always returns "passed"; the truthiness lives in the variable.
+            sr.Set_Shared_Variables(variable_name, value if found else "false")
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"Element {'found' if found else 'not found'} - saved '{value if found else 'false'}' to '{variable_name}'",
+                1,
+            )
+            return "passed"
+
+        if found:
+            CommonUtil.ExecLog(sModuleInfo, "Element exists", 1)
+            return "passed"
+        CommonUtil.ExecLog(sModuleInfo, "Element does not exist", 1)
+        return "zeuz_failed"
 
     except Exception:
-        return CommonUtil.Exception_Handler(sys.exc_info())
+        errMsg = "Failed to parse data/locate element. Data format: variableName = value"
+        return CommonUtil.Exception_Handler(sys.exc_info(), None, errMsg)
 
 
 @logger
@@ -1426,7 +1777,13 @@ async def Save_Attribute(step_data):
     """
     Save an element's attribute value to a shared variable.
 
-    Example:
+    Selenium-compatible form (recommended):
+        Field               Sub Field           Value
+        id                  element parameter   my-link
+        href                save parameter      my_variable
+        save attribute      playwright action   save attribute
+
+    Alternative form (attribute via input parameter):
         Field               Sub Field           Value
         id                  element parameter   my-link
         href                input parameter     attribute_name
@@ -1434,13 +1791,15 @@ async def Save_Attribute(step_data):
         save attribute      playwright action   save attribute
 
     Special attribute names:
-        - text: Get text content
-        - innertext: Get inner text
-        - innerhtml: Get inner HTML
-        - outerhtml: Get outer HTML
-        - value: Get input value
-        - checked: Get checkbox state
-        - selected: Get select option state
+        - text:       text content (Selenium .text)
+        - tag:        tag name (Selenium .tag_name)
+        - checked:    checkbox/radio selected state
+        - innertext:  inner text
+        - innerhtml:  inner HTML
+        - outerhtml:  outer HTML
+        - value:      input value
+        - selected:   <option> selected state
+        - visible / enabled / disabled
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global current_page
@@ -1450,38 +1809,53 @@ async def Save_Attribute(step_data):
             CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
             return "zeuz_failed"
 
-        attribute_name = None
-        save_variable = None
-        save_attribute = None
+        attribute_name = None  # Attribute to read (e.g. "text", "href")
+        save_variable = None   # Shared variable to write
+        # Build a locator-only data set by excluding the save row (mirrors Selenium).
+        new_ds = []
 
         for left, mid, right in step_data:
-            left_l = left.strip().lower()
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l in ["input parameter", "element parameter"]:
-                attribute_name = left.strip()  # Keep original case
-            elif mid_l == "save parameter":
-                save_variable = right_v
-                save_attribute = left_l
+            if mid_l == "save parameter":
+                # Selenium-style: left = attribute, right = variable name.
+                # Playwright legacy style: left = variable, right = "ignore".
+                if right_v and right_v.lower() not in ("ignore", "n/a", "na", ""):
+                    save_variable = right_v
+                    if not attribute_name:
+                        attribute_name = left.strip()
+                else:
+                    save_variable = left.strip()
+            elif mid_l == "input parameter":
+                # Legacy Playwright style: attribute name lives in input parameter
+                attribute_name = left.strip()
+            else:
+                new_ds.append((left, mid, right))
+
+        if not save_variable:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                "Variable name should be mentioned. Example: (text, save parameter, var_name)",
+                3,
+            )
+            return "zeuz_failed"
 
         if not attribute_name:
             CommonUtil.ExecLog(sModuleInfo, "No attribute name specified", 3)
             return "zeuz_failed"
 
-        if not save_variable:
-            CommonUtil.ExecLog(sModuleInfo, "No save variable specified", 3)
-            return "zeuz_failed"
-
-        locator = await PlaywrightLocator.Get_Element(step_data, current_page, frame_locator=_get_frame_locator())
+        locator = await PlaywrightLocator.Get_Element(new_ds, current_page, frame_locator=_get_frame_locator())
         if locator == "zeuz_failed":
-            CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
+            CommonUtil.ExecLog(sModuleInfo, "Unable to locate your element with given data.", 3)
             return "zeuz_failed"
 
         # Get attribute value based on name
         attr_lower = attribute_name.lower()
         if attr_lower == "text":
             value = await locator.text_content()
+        elif attr_lower == "tag":
+            value = (await locator.evaluate("el => el.tagName") or "").lower()
         elif attr_lower == "innertext":
             value = await locator.inner_text()
         elif attr_lower == "innerhtml":
@@ -1501,10 +1875,17 @@ async def Save_Attribute(step_data):
         elif attr_lower == "disabled":
             value = await locator.is_disabled()
         else:
-            value = await locator.get_attribute(save_attribute)
+            value = await locator.get_attribute(attribute_name)
 
-        sr.Set_Shared_Variables(save_variable, value)
-        CommonUtil.ExecLog(sModuleInfo, f"Saved '{save_attribute}' = '{value}' to '{save_variable}'", 1)
+        result = sr.Set_Shared_Variables(save_variable, value)
+        if result in failed_tag_list:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"Value of Variable '{save_variable}' could not be saved!!!",
+                3,
+            )
+            return "zeuz_failed"
+        CommonUtil.ExecLog(sModuleInfo, f"Saved '{attribute_name}' = '{value}' to '{save_variable}'", 1)
         return "passed"
 
     except Exception:
@@ -1739,11 +2120,29 @@ async def scroll_to_element(step_data):
     """
     Scroll an element into view.
 
-    Example:
+    Example 1 - Basic:
         Field               Sub Field           Value
         id                  element parameter   footer
-        use js              optional parameter  false
         scroll to element   playwright action   scroll to element
+
+    Example 2 - Selenium-compatible options:
+        Field               Sub Field           Value
+        id                  element parameter   footer
+        use js              optional parameter  true
+        align to top        optional parameter  true
+        method              optional parameter  js
+        additional scroll   optional parameter  0.1
+        scroll to element   playwright action   scroll to element
+
+    Options:
+        - use js (true/false): Use element.scrollIntoView() via JS.
+        - align to top (true/false): When using JS, align element to top of viewport.
+        - method (js | webdriver | action chain): Which scroll mechanism to use.
+            * js (default): element.scrollIntoView()
+            * webdriver: Playwright's scroll_into_view_if_needed()
+            * action chain: Hover the element so it is brought into view by the engine.
+        - additional scroll (fraction, e.g. 0.1): After scrolling into view, scroll an
+          additional fraction of the viewport in the direction the page just moved.
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global current_page
@@ -1753,35 +2152,861 @@ async def scroll_to_element(step_data):
             CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
             return "zeuz_failed"
 
-        use_js = False
-        align_to_top = True
+        method = "js"
+        align_to_top = "true"
+        additional_scroll = 0.0
+        direction = ""
 
         for left, mid, right in step_data:
             left_l = left.strip().lower()
             mid_l = mid.strip().lower()
-            right_v = right.strip()
+            right_v = right.strip().lower()
 
             if mid_l == "optional parameter":
                 if left_l == "use js":
-                    use_js = right_v.lower() in ("true", "yes", "1")
+                    method = "js" if right_v in ("true", "yes", "1") else "action chain"
                 elif left_l == "align to top":
-                    align_to_top = right_v.lower() in ("true", "yes", "1")
+                    align_to_top = "true" if right_v in ("true", "yes", "1") else "false"
+                elif left_l == "method":
+                    method = right_v
+                elif "additional scroll" in left_l:
+                    try:
+                        additional_scroll = float(right_v)
+                    except ValueError:
+                        additional_scroll = 0.0
 
-        locator = await PlaywrightLocator.Get_Element(step_data, current_page, frame_locator=_get_frame_locator())
+        locator = await PlaywrightLocator.Get_Element(
+            step_data, current_page, frame_locator=_get_frame_locator()
+        )
         if locator == "zeuz_failed":
-            CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
+            CommonUtil.ExecLog(sModuleInfo, "Element to which instructed to scroll not found", 3)
             return "zeuz_failed"
 
-        if use_js:
-            await locator.evaluate(f"el => el.scrollIntoView({str(align_to_top).lower()})")
-        else:
-            await locator.scroll_into_view_if_needed()
+        top, left_pos = None, None
+        if not direction and additional_scroll > 0:
+            try:
+                top, left_pos = await current_page.evaluate(
+                    "() => [window.pageYOffset || document.documentElement.scrollTop,"
+                    " window.pageXOffset || document.documentElement.scrollLeft]"
+                )
+            except Exception:
+                top, left_pos = None, None
 
-        CommonUtil.ExecLog(sModuleInfo, "Scrolled element into view", 1)
+        if method == "js":
+            await locator.evaluate(f"el => el.scrollIntoView({align_to_top})")
+        elif method == "webdriver":
+            await locator.scroll_into_view_if_needed()
+        else:
+            # "action chain" -> hover brings element into view in Playwright.
+            await locator.hover()
+
+        CommonUtil.ExecLog(sModuleInfo, f"Scrolled to view with method = {method}", 1)
+
+        if (
+            not direction
+            and additional_scroll > 0
+            and top is not None
+            and left_pos is not None
+        ):
+            try:
+                new_top, new_left = await current_page.evaluate(
+                    "() => [window.pageYOffset || document.documentElement.scrollTop,"
+                    " window.pageXOffset || document.documentElement.scrollLeft]"
+                )
+                if new_top > top:
+                    direction = "down"
+                elif new_top < top:
+                    direction = "up"
+                elif new_left > left_pos:
+                    direction = "right"
+                elif new_left < left_pos:
+                    direction = "left"
+                else:
+                    direction = ""
+            except Exception:
+                direction = ""
+
+            if (
+                method in ("js", "webdriver")
+                and (
+                    (align_to_top == "true" and direction in ("down", "right"))
+                    or (align_to_top == "false" and direction in ("up", "left"))
+                )
+            ):
+                direction = ""
+
+        if direction and additional_scroll > 0:
+            await asyncio.sleep(1)
+            viewport = current_page.viewport_size or {"width": 1280, "height": 720}
+            axis = "height" if direction in ("up", "down") else "width"
+            pixels = round(viewport[axis] * additional_scroll)
+            offset = _generate_scroll_offset(direction, pixels)
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"Doing additional scroll in {direction} direction, {additional_scroll * 100}% of "
+                f"{axis} of html body, ({offset}) pixels",
+                1,
+            )
+            await current_page.evaluate(f"window.scrollBy({offset})")
+
         return "passed"
 
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())
+
+
+def _generate_scroll_offset(direction: str, pixel: int) -> str:
+    if direction == "down":
+        return f"0,{pixel}"
+    if direction == "up":
+        return f"0,-{pixel}"
+    if direction == "left":
+        return f"-{pixel},0"
+    if direction == "right":
+        return f"{pixel},0"
+    return "0,0"
+
+
+_SCROLL_TO_TOP_JS = """
+(() => {
+    var pre_x = window.pageXOffset;
+    var pre_y = window.pageYOffset;
+    window.scrollTo(window.pageXOffset, 0);
+    return [pre_x, pre_y, window.pageXOffset, window.pageYOffset];
+})()
+"""
+
+
+def _is_session_step_row(left, mid):
+    return _normalize_step_mid(mid) == "optionalparameter" and left.strip().lower() == "session"
+
+
+def _normalize_step_mid(mid):
+    """Match LocateElement: ignore spaces/newlines in sub-field names."""
+    return (
+        mid.replace(" ", "")
+        .replace("\n", "")
+        .replace("\r", "")
+        .replace("\t", "")
+        .lower()
+    )
+
+
+def _is_element_parameter_mid(mid):
+    mid_norm = _normalize_step_mid(mid)
+    return mid_norm == "elementparameter" or (
+        "element" in mid_norm and "parameter" in mid_norm and "target" not in mid_norm
+    )
+
+
+def _is_target_parameter_mid(mid):
+    mid_norm = _normalize_step_mid(mid)
+    # UI may show only "target" on one line; "parameter" on the next (full name is still one row in data).
+    return mid_norm in ("targetparameter", "target") or (
+        "target" in mid_norm and "parameter" in mid_norm
+    )
+
+
+def _resolve_list_action_variable_name(left, mid, right, action_key):
+    """
+    Read shared-variable name from a save-*-in-list action row.
+
+    Zeuz may send the variable in the Value column (right) or Field column (left)
+    when the other column repeats the action keyword.
+    """
+    left_raw = left.strip()
+    right_raw = right.strip()
+    left_norm = left_raw.lower().replace(" ", "").replace("_", "")
+    right_norm = right_raw.lower().replace(" ", "").replace("_", "")
+    mid_norm = _normalize_step_mid(mid)
+
+    if left_norm == action_key:
+        if right_norm and right_norm != action_key:
+            return right_raw
+        return None
+
+    if mid_norm in ("playwrightaction", "seleniumaction"):
+        if right_norm == action_key and left_norm and left_norm != action_key:
+            return left_raw
+        if right_norm and right_norm != action_key:
+            return right_raw
+    return None
+
+
+def _require_playwright_page(step_data, sModuleInfo):
+    """Activate session from step_data and ensure a page is open."""
+    global current_page
+    _handle_playwright_session(step_data)
+    if current_page is None:
+        CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
+        return "zeuz_failed"
+    return current_page
+
+
+async def _read_element_attribute_for_list(locator, attribute_name):
+    if attribute_name == "text":
+        return await locator.inner_text()
+    if attribute_name == "tag":
+        tag = await locator.evaluate("el => el.tagName")
+        return tag.lower() if tag else ""
+    if attribute_name == "checked":
+        return str(await locator.is_checked())
+    return await locator.get_attribute(attribute_name)
+
+
+def _apply_return_contains_filter(value, contains_rules):
+    if not contains_rules:
+        return value
+    for rule in contains_rules:
+        if (
+            not isinstance(rule, type(value))
+            or rule in value
+            or len(rule) == 0
+        ):
+            break
+    else:
+        return None
+    return value
+
+
+def _apply_return_does_not_contain_filter(value, exclude_rules):
+    for rule in exclude_rules:
+        if (
+            isinstance(rule, type(value))
+            and rule in value
+            and len(rule) != 0
+        ):
+            return None
+    return value
+
+
+def _target_param_continues_previous_target(right):
+    """True when this target-parameter row adds return/filter rules to the prior target."""
+    text = right.strip().lower()
+    return text.startswith(
+        ("return", "return_contains", "return_does_not_contain", "allow hidden", "allowhidden")
+    )
+
+
+def _parse_target_kv_pairs(right, split_on_newline=False, field_hint=None):
+    """Parse target parameter value into (key, value) pairs.
+
+    Matches Selenium semantics for both list actions:
+      - save_attribute_values_in_list expects bare-string filter values:
+            return_contains="128GB" -> ('return_contains', '128GB')
+      - save_web_elements_in_list expects (attr, needle) filter pairs:
+            return_contains="text=128GB" -> ('return_contains', ('text', '128GB'))
+
+    The shape used depends on whether the value (after quote-stripping) has an
+    inner '=', mirroring Selenium's `each.split("=")` behavior on a list of length
+    1 vs 2.
+    """
+    text = right.strip().rstrip(",")
+    # UI may use comma-only (one line) or comma+newline (multi-line) separators.
+    if split_on_newline and ",\n" in text:
+        chunks = text.split(",\n")
+    else:
+        chunks = text.split(",")
+    pairs = []
+    hint = (field_hint or "").strip().lower() or "class"
+    for chunk in chunks:
+        chunk = chunk.strip().rstrip(",")
+        if not chunk:
+            continue
+        if "=" not in chunk:
+            if hint:
+                # Shorthand: "productItemName" with Field column "class"
+                pairs.append((hint, chunk))
+            else:
+                pairs.append((chunk, ""))
+            continue
+
+        key, value = chunk.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if key in ("return_contains", "return_does_not_contain"):
+            # Strip the wrapping quotes (if any) on the value first; an INNER '='
+            # then signals the attr=needle pair form used by save_web_elements_in_list.
+            inner = CommonUtil.strip1(value, '"')
+            if "=" in inner:
+                attr, needle = inner.split("=", 1)
+                pairs.append((key, (attr.strip(), needle.strip())))
+            else:
+                pairs.append((key, inner))
+        else:
+            pairs.append((key, value))
+    return pairs
+
+
+def _normalize_target_pair_values(pairs):
+    normalized = []
+    for pair in pairs:
+        if len(pair) == 1:
+            normalized.append((pair[0].strip(), ""))
+            continue
+        key, value = pair[0], pair[1]
+        key = key.strip() if isinstance(key, str) else key
+        if isinstance(value, str):
+            value = CommonUtil.strip1(value.strip(), '"')
+        elif isinstance(value, tuple) and len(value) == 2:
+            value = (
+                CommonUtil.strip1(value[0].strip(), '"'),
+                CommonUtil.strip1(value[1].strip(), '"'),
+            )
+        elif isinstance(value, list) and len(value) == 2:
+            value = (value[0].strip().strip('"'), value[1].strip().strip('"'))
+        normalized.append((key, value))
+    pairs[:] = normalized
+
+
+def _append_target_spec(target_specs, key, value, spec_index):
+    spec = target_specs[spec_index]
+    if key == "return":
+        spec[1] = value
+    elif key == "return_contains":
+        spec[2].append(value)
+    elif key == "return_does_not_contain":
+        spec[3].append(value)
+    elif key.replace(" ", "").replace("_", "") in ("allowhidden", "allowdisable"):
+        spec[0].append(("allow hidden", "optional parameter", value))
+    else:
+        spec[0].append((key, "element parameter", value))
+
+
+async def _element_matches_return_contains(elem, rules):
+    text = await elem.inner_text()
+    tag = (await elem.evaluate("el => el.tagName")).lower()
+    for attr, needle in rules:
+        if attr == "text" and needle in text:
+            return True
+        if attr == "tag" and needle in tag:
+            return True
+        if attr not in ("text", "tag"):
+            attr_val = await elem.get_attribute(attr)
+            if attr_val is None:
+                return False
+            if needle in attr_val:
+                return True
+    return False
+
+
+async def _element_matches_return_does_not_contain(elem, rules):
+    text = await elem.inner_text()
+    tag = (await elem.evaluate("el => el.tagName")).lower()
+    for attr, needle in rules:
+        if attr == "text" and needle in text:
+            return True
+        if attr == "tag" and needle in tag:
+            return True
+        if attr not in ("text", "tag"):
+            attr_val = await elem.get_attribute(attr)
+            if attr_val is None or needle in (attr_val or ""):
+                return True
+    return False
+
+
+async def _filter_elements_return_contains(elements, contains_rules):
+    if not contains_rules:
+        return elements
+    filtered = []
+    for elem in elements:
+        if await _element_matches_return_contains(elem, contains_rules):
+            filtered.append(elem)
+    return filtered
+
+
+async def _filter_elements_return_does_not_contain(elements, exclude_rules):
+    if not exclude_rules:
+        return elements
+    return [
+        elem
+        for elem in elements
+        if not await _element_matches_return_does_not_contain(elem, exclude_rules)
+    ]
+
+
+@logger
+async def scroll_to_top(step_data):
+    """
+    Scroll the browser window to the top of the page (vertical offset 0).
+
+    Example:
+        Field               Sub Field           Value
+        scroll to top       playwright action   scroll to top
+    """
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+
+    try:
+        page = _require_playwright_page(step_data, sModuleInfo)
+        if page == "zeuz_failed":
+            return "zeuz_failed"
+
+        pre_x, pre_y, x, y = await page.evaluate(_SCROLL_TO_TOP_JS)
+        CommonUtil.ExecLog(
+            sModuleInfo,
+            f"Scrolled to top of the html.\npre_x, pre_y, x, y = [{pre_x}, {pre_y}, {x}, {y}]",
+            1 if (x, y) == (0, 0) else 2,
+        )
+        return "passed"
+
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())
+
+
+@logger
+async def save_attribute_values_in_list(step_data):
+    """
+    Collect attribute or text values from multiple child element groups under a parent.
+
+    Each target parameter block defines locators plus optional return filters. Results are
+    stored in a shared variable as rows (paired) or columns (paired=no).
+
+    Example 1 - Product names and prices:
+        Field                               Sub Field           Value
+        aria-label                          element parameter   Calendar
+        attributes                          target parameter    data-automation="productItemName",
+                                                                class="S58f2saa25a3w1",
+                                                                return="text"
+        attributes                          target parameter    class="productPricingContainer_3gTS3",
+                                                                return="text",
+                                                                return_does_not_contain="99.99"
+        save attribute values in list       playwright action   product_rows
+
+    Example 2 - Unpaired columns:
+        Field                               Sub Field           Value
+        tag                                 element parameter   html
+        class                               target parameter    item, return="text"
+        class                               target parameter    price, return="text"
+        paired                              optional parameter  no
+        save attribute values in list       playwright action   columns_list
+    """
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global current_page
+
+    try:
+        if _require_playwright_page(step_data, sModuleInfo) == "zeuz_failed":
+            return "zeuz_failed"
+
+        frame = _get_frame_locator()
+        parent = await PlaywrightLocator.Get_Element(step_data, current_page, frame_locator=frame)
+        if parent == "zeuz_failed":
+            CommonUtil.ExecLog(
+                sModuleInfo, "Unable to locate your element with given data.", 3
+            )
+            return "zeuz_failed"
+
+        targets = []
+        variable_name = ""
+        paired = True
+
+        try:
+            spec_index = -1
+            for left, mid, right in step_data:
+                if _is_session_step_row(left, mid):
+                    continue
+                left_l = left.strip().lower()
+                left_key = left_l.replace(" ", "").replace("_", "")
+                right = right.strip()
+                if _is_target_parameter_mid(mid):
+                    if spec_index >= 0 and _target_param_continues_previous_target(right):
+                        pass  # append to current target spec
+                    else:
+                        targets.append([[], "", [], []])
+                        spec_index += 1
+                    pairs = _parse_target_kv_pairs(
+                        right, split_on_newline=True, field_hint=left_l
+                    )
+                    _normalize_target_pair_values(pairs)
+                    for key, value in pairs:
+                        _append_target_spec(targets, key, value, spec_index)
+                else:
+                    var_candidate = _resolve_list_action_variable_name(
+                        left,
+                        mid,
+                        right,
+                        "saveattributevaluesinlist",
+                    )
+                    if var_candidate:
+                        variable_name = var_candidate
+                if left_l == "paired":
+                    paired = right.lower() != "no"
+            if not targets:
+                CommonUtil.ExecLog(sModuleInfo, "No target parameter rows found in step data", 3)
+                return "zeuz_failed"
+            if not variable_name:
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    "No variable name for save attribute values in list (set action value e.g. product_data)",
+                    3,
+                )
+                return "zeuz_failed"
+        except Exception as exc:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"Unable to parse data. Please write data in correct format ({exc})",
+                3,
+            )
+            return "zeuz_failed"
+
+        element_groups = []
+        for locator_rows, return_attr, contains_rules, exclude_rules in targets:
+            elements = await PlaywrightLocator.Get_Element(
+                locator_rows,
+                current_page,
+                return_all=True,
+                frame_locator=frame,
+                parent_locator=parent,
+            )
+            if elements == "zeuz_failed":
+                CommonUtil.ExecLog(sModuleInfo, "Unable to locate target elements.", 3)
+                return "zeuz_failed"
+            element_groups.append((elements, return_attr, contains_rules, exclude_rules))
+
+        max_len = max((len(group[0]) for group in element_groups), default=0)
+        rows = [[] for _ in range(max_len)]
+
+        for elements, return_attr, contains_rules, exclude_rules in element_groups:
+            for index, elem in enumerate(elements):
+                value = await _read_element_attribute_for_list(elem, return_attr)
+                try:
+                    value = _apply_return_contains_filter(value, contains_rules)
+                    value = _apply_return_does_not_contain_filter(value, exclude_rules)
+                except Exception:
+                    CommonUtil.ExecLog(
+                        sModuleInfo,
+                        "Couldn't search by return_contains and return_does_not_contain",
+                        2,
+                    )
+                rows[index].append(value)
+
+        if len(targets) == 1:
+            # Match Selenium: one target => flat list of values (all elements), not rows[0] only.
+            result = list(map(list, zip(*rows)))[0] if rows else []
+        elif not paired:
+            result = list(map(list, zip(*rows))) if rows else []
+        else:
+            result = rows
+
+        return sr.Set_Shared_Variables(variable_name, result)
+
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())
+
+
+_ELEMENT_SCOPE_MIDS = frozenset(
+    {
+        "element parameter",
+        "parent parameter",
+        "unique parameter",
+        "child parameter",
+        "sibling parameter",
+    }
+)
+
+
+@logger
+async def save_web_elements_in_list(step_data):
+    """
+    Save Playwright locators for multiple element groups into a shared variable.
+
+    Optional parent scope limits the search. Use return_contains / return_does_not_contain
+    in target parameters to filter matched elements before saving.
+
+    Example 1 - Under a container:
+        Field                           Sub Field           Value
+        id                              element parameter   product-list
+        class                           target parameter    item, return_contains=text=Phone
+        save web elements in list       playwright action   phone_items
+
+    Example 2 - Whole page (no parent rows):
+        Field                           Sub Field           Value
+        class                           target parameter    btn-primary
+        save web elements in list       playwright action   all_buttons
+    """
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global current_page
+
+    try:
+        if _require_playwright_page(step_data, sModuleInfo) == "zeuz_failed":
+            return "zeuz_failed"
+
+        frame = _get_frame_locator()
+        targets = []
+        variable_name = ""
+        has_parent_scope = False
+
+        try:
+            spec_index = -1
+            for left, mid, right in step_data:
+                if _is_session_step_row(left, mid):
+                    continue
+                left = left.strip().lower()
+                mid = mid.strip().lower()
+                right = right.strip()
+                if not has_parent_scope and _is_element_parameter_mid(mid):
+                    has_parent_scope = True
+                elif _is_target_parameter_mid(mid):
+                    if spec_index >= 0 and _target_param_continues_previous_target(right):
+                        pass
+                    else:
+                        targets.append([[], [], [], []])
+                        spec_index += 1
+                    pairs = _parse_target_kv_pairs(right, field_hint=left)
+                    _normalize_target_pair_values(pairs)
+                    for key, value in pairs:
+                        _append_target_spec(targets, key, value, spec_index)
+                else:
+                    var_candidate = _resolve_list_action_variable_name(
+                        left,
+                        mid,
+                        right,
+                        "savewebelementsinlist",
+                    )
+                    if var_candidate:
+                        variable_name = var_candidate
+
+            if has_parent_scope:
+                parent = await PlaywrightLocator.Get_Element(
+                    step_data, current_page, frame_locator=frame
+                )
+                if parent == "zeuz_failed":
+                    CommonUtil.ExecLog(
+                        sModuleInfo, "Unable to locate your element with given data.", 3
+                    )
+                    return "zeuz_failed"
+            else:
+                parent = None
+        except Exception:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                "Unable to parse data. Please write data in correct format",
+                3,
+            )
+            return "zeuz_failed"
+
+        element_lists = []
+        for locator_rows, _return_attr, contains_rules, exclude_rules in targets:
+            elements = await PlaywrightLocator.Get_Element(
+                locator_rows,
+                current_page,
+                return_all=True,
+                frame_locator=frame,
+                parent_locator=parent,
+            )
+            if elements == "zeuz_failed":
+                CommonUtil.ExecLog(sModuleInfo, "Unable to locate target elements.", 3)
+                return "zeuz_failed"
+            elements = await _filter_elements_return_contains(elements, contains_rules)
+            elements = await _filter_elements_return_does_not_contain(elements, exclude_rules)
+            element_lists.append(elements)
+
+        if len(targets) == 1:
+            return sr.Set_Shared_Variables(variable_name, element_lists[0])
+        return sr.Set_Shared_Variables(variable_name, element_lists)
+
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())
+
+
+def _insert_string_targets(string: str, str_to_insert: str, index: int) -> str:
+    return string[:index] + str_to_insert + string[index:]
+
+
+def _parse_multiple_check_targets(target_parameter_value):
+    """Parse target parameter string into (locator_key, locator_value, action) tuples."""
+    inside = False
+    temp = target_parameter_value.strip()
+    i = 0
+    while i < len(temp):
+        if temp[i] == "(":
+            inside = True
+            temp = _insert_string_targets(temp, '"', i + 1)
+        elif inside and temp[i] == ",":
+            temp = _insert_string_targets(temp, '"', i + 1)
+            temp = _insert_string_targets(temp, '"', i)
+            i += 1
+        elif temp[i] == ")":
+            inside = False
+            temp = _insert_string_targets(temp, '"', i)
+            i += 1
+        i += 1
+    temp = _insert_string_targets(temp, "[", 0)
+    temp = _insert_string_targets(temp, "]", len(temp))
+    parsed = CommonUtil.parse_value_into_object(temp)
+    return [
+        (row[0].strip().lower(), row[1].strip(), row[2].strip().lower())
+        for row in parsed
+    ]
+
+
+async def _toggle_checkbox_target(locator, action, use_js, target_label):
+    """Check or uncheck one target; logs and swallows per-target failures like Selenium."""
+    if action == "check" and await locator.is_checked():
+        CommonUtil.ExecLog("", f"{target_label} is already checked so skipped it", 1)
+        return
+    if action == "uncheck" and not await locator.is_checked():
+        CommonUtil.ExecLog("", f"{target_label} is already unchecked so skipped it", 1)
+        return
+
+    via_js = use_js
+    try:
+        if use_js:
+            await locator.evaluate("el => el.click()")
+        else:
+            try:
+                await locator.click()
+            except Exception:
+                await locator.evaluate("el => el.click()")
+                via_js = True
+        verb = "checked" if action == "check" else "unchecked"
+        suffix = " using Java Script" if via_js else ""
+        CommonUtil.ExecLog("", f"{target_label} is {verb} successfully{suffix}", 1)
+    except Exception:
+        verb = "checked" if action == "check" else "unchecked"
+        CommonUtil.ExecLog("", f"{target_label} couldn't be {verb} so skipped it", 3)
+
+
+@logger
+async def multiple_check_uncheck(data_set):
+    """
+    Check or uncheck multiple checkbox/radio elements under one parent.
+
+    Each entry in target parameter is (locator field, locator value, check|uncheck).
+    Missing targets are skipped; the step still returns passed.
+
+    Example 1 - Basic:
+        Field                       Sub Field           Value
+        id                          element parameter   form-panel
+        target parameter            target parameter    (id, opt-a, check), (id, opt-b, uncheck)
+        multiple check uncheck      playwright action   multiple check uncheck
+
+    Example 2 - JavaScript click:
+        Field                       Sub Field           Value
+        class                       element parameter   options-group
+        use js                      optional parameter  true
+        allow hidden                optional parameter  yes
+        target parameter            target parameter    (name, hidden-opt, check)
+        multiple check uncheck      playwright action   multiple check uncheck
+    """
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global current_page
+
+    use_js = False
+    allow_hidden = ""
+    targets = None
+
+    try:
+        for left, mid, right in data_set:
+            left = left.lower().strip()
+            mid = mid.lower().strip()
+            if _is_session_step_row(left, mid):
+                continue
+            if left == "use js":
+                use_js = right.strip().lower() in ("true", "yes", "ok")
+            elif left == "allow hidden":
+                allow_hidden = right
+            elif mid == "target parameter":
+                targets = _parse_multiple_check_targets(right)
+
+    except Exception:
+        return CommonUtil.Exception_Handler(
+            sys.exc_info(), None, "Error parsing data set"
+        )
+
+    if not targets:
+        CommonUtil.ExecLog(sModuleInfo, "No target parameter found in step data", 3)
+        return "zeuz_failed"
+
+    try:
+        if _require_playwright_page(data_set, sModuleInfo) == "zeuz_failed":
+            return "zeuz_failed"
+
+        frame = _get_frame_locator()
+        parent = await PlaywrightLocator.Get_Element(data_set, current_page, frame_locator=frame)
+        if parent == "zeuz_failed":
+            CommonUtil.ExecLog(sModuleInfo, "Could not find the parent element", 3)
+            return "zeuz_failed"
+
+        for locator_key, locator_value, action in targets:
+            locate_rows = [(locator_key, "element parameter", locator_value)]
+            if allow_hidden:
+                locate_rows.insert(0, ("allow hidden", "option", allow_hidden))
+
+            locator = await PlaywrightLocator.Get_Element(
+                locate_rows, current_page, frame_locator=frame, parent_locator=parent
+            )
+            target_label = str((locator_key, locator_value, action))
+            if locator == "zeuz_failed":
+                CommonUtil.ExecLog("", f"{target_label} was not found so skipped it", 3)
+                continue
+
+            await _toggle_checkbox_target(locator, action, use_js, target_label)
+
+        return "passed"
+
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())
+
+
+@logger
+async def Change_Attribute_Value(step_data):
+    """
+    Set a DOM property on the located element via JavaScript (same idea as Selenium).
+
+    The left column of an input parameter row is the property name; the right column is the value.
+
+    Example 1 - Input value:
+        Field                       Sub Field           Value
+        id                          element parameter   email-field
+        value                       input parameter     user@example.com
+        change attribute value      playwright action   change attribute value
+
+    Example 2 - Read-only flag:
+        Field                       Sub Field           Value
+        id                          element parameter   age-input
+        readOnly                    input parameter     true
+        change attribute value      playwright action   change attribute value
+    """
+    sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
+    global current_page
+
+    try:
+        if _require_playwright_page(step_data, sModuleInfo) == "zeuz_failed":
+            return "zeuz_failed"
+
+        attribute_name = ""
+        change_value = ""
+        for left, mid, right in step_data:
+            if _is_session_step_row(left, mid):
+                continue
+            if "input parameter" in mid.strip().lower():
+                attribute_name = left.strip().lower()
+                change_value = right
+
+        locator = await PlaywrightLocator.Get_Element(
+            step_data, current_page, frame_locator=_get_frame_locator()
+        )
+        if locator == "zeuz_failed":
+            CommonUtil.ExecLog(
+                sModuleInfo, "Unable to locate your element with given data.", 3
+            )
+            return "zeuz_failed"
+
+        await locator.evaluate(
+            "(el, payload) => { el[payload.name] = payload.value; }",
+            {"name": attribute_name, "value": change_value},
+        )
+        CommonUtil.ExecLog(
+            sModuleInfo,
+            f"Successfully set the value of the attribute to: {change_value}",
+            1,
+        )
+        return "passed"
+
+    except Exception:
+        return CommonUtil.Exception_Handler(
+            sys.exc_info(), None, "Could not find your element."
+        )
 
 
 #########################
@@ -2186,15 +3411,27 @@ async def switch_iframe(step_data):
         id                  iframe parameter    my-iframe
         switch iframe       playwright action   switch iframe
 
-    Example 2 - Switch by index:
+    Example 2 - Switch by index (positive or negative):
         Field               Sub Field           Value
-        index               input parameter     0
+        index               iframe parameter    0
         switch iframe       playwright action   switch iframe
 
     Example 3 - Switch to default/main:
         Field               Sub Field           Value
         index               input parameter     default content
         switch iframe       playwright action   switch iframe
+
+    Example 4 - Nested frames (multiple rows, applied in order):
+        Field               Sub Field           Value
+        id                  iframe parameter    outer-frame
+        id                  iframe parameter    inner-frame
+        switch iframe       playwright action   switch iframe
+
+    Behavior notes (Selenium-compatible):
+        - Index lookup is retried (up to 5 times, 2s apart) to wait for iframes to load.
+        - Negative indexes are supported (-1 = last iframe).
+        - If a target cannot be located in the current context, this walks
+          back to parent frames and retries.
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global current_page
@@ -2225,7 +3462,14 @@ async def switch_iframe(step_data):
                 continue
 
             if left_l == "index":
-                frame_targets.append({"kind": "index", "mid": mid_l, "right": right_v})
+                frame_targets.append(
+                    {
+                        "kind": "index",
+                        "mid": mid_l if mid_l in ("iframe parameter", "frame parameter") else "iframe parameter",
+                        "left": left_l,
+                        "right": right_v,
+                    }
+                )
             elif mid_l in ("iframe parameter", "frame parameter"):
                 frame_targets.append(
                     {
@@ -2237,11 +3481,9 @@ async def switch_iframe(step_data):
                 )
 
         if switch_to_default:
-            # In Playwright, we work with the main page directly
-            # Store a flag or reset frame locator
             sr.Set_Shared_Variables("playwright_frame", None)
             _save_current_playwright_frame(None)
-            CommonUtil.ExecLog(sModuleInfo, "Switched to default content", 1)
+            CommonUtil.ExecLog(sModuleInfo, "Exited all iframes and switched to default content", 1)
             if not frame_targets:
                 return "passed"
 
@@ -2249,38 +3491,123 @@ async def switch_iframe(step_data):
             CommonUtil.ExecLog(sModuleInfo, "No iframe selector or index provided", 3)
             return "zeuz_failed"
 
-        frame_locator = None
-        for target in frame_targets:
-            base = frame_locator if frame_locator else current_page
+        def _build_selector(target):
             tag_name = "frame" if target["mid"] == "frame parameter" else "iframe"
-
-            if target["kind"] == "index":
-                try:
-                    iframe_index = int(target["right"])
-                except Exception:
-                    CommonUtil.ExecLog(
-                        sModuleInfo,
-                        "Invalid %s index '%s'" % (tag_name, target["right"]),
-                        3,
-                    )
-                    return "zeuz_failed"
-                frame_locator = base.frame_locator(tag_name).nth(iframe_index)
-                continue
-
             left_l = target["left"]
             right_v = target["right"]
             if left_l == "tag":
-                iframe_selector = right_v
-            elif left_l == "xpath":
-                iframe_selector = right_v if right_v.startswith("xpath=") else f"xpath={right_v}"
-            else:
-                iframe_selector = f"{tag_name}[{left_l}='{right_v}']"
-            frame_locator = base.frame_locator(iframe_selector)
+                return tag_name, right_v
+            if left_l == "xpath":
+                expr = right_v if right_v.startswith("xpath=") else f"xpath={right_v}"
+                return tag_name, expr
+            return tag_name, f"{tag_name}[{left_l}='{right_v}']"
 
-        # Store frame locator for subsequent actions
+        async def _resolve_index(base, tag_name, idx_str):
+            try:
+                idx = int(idx_str)
+            except Exception:
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    f"Invalid {tag_name} index '{idx_str}'",
+                    3,
+                )
+                return None, "fatal"
+            # Retry to wait for iframes to load (mirrors Selenium 5x2s loop).
+            for _ in range(5):
+                try:
+                    count = await base.locator(tag_name).count()
+                except Exception:
+                    count = 0
+                if count and -count <= idx < count:
+                    break
+                await asyncio.sleep(2)
+            else:
+                return None, "not_found"
+            log_idx = idx
+            if idx < 0:
+                idx = count + idx
+            CommonUtil.ExecLog(sModuleInfo, f"Iframe switched to index {log_idx}", 1)
+            return base.frame_locator(tag_name).nth(idx), "passed"
+
+        async def _resolve_selector(base, target):
+            tag_name, selector = _build_selector(target)
+            try:
+                fl = base.frame_locator(selector)
+                # Probe count; Playwright frame_locator does not auto-validate existence here.
+                if await base.locator(selector).count() == 0:
+                    return None, "not_found"
+                CommonUtil.ExecLog(sModuleInfo, "Iframe switched using above Xpath", 1)
+                return fl, "passed"
+            except Exception:
+                return None, "not_found"
+
+        active_stack = []  # list of frame_locators resolved so far
+        pending = frame_targets[:]
+        unknown_parent_hops = 0
+        max_unknown_parent_hops = len(frame_targets) + 5
+
+        def _current_base():
+            return active_stack[-1] if active_stack else current_page
+
+        while pending:
+            switched = False
+            for idx, target in enumerate(pending):
+                base = _current_base()
+                tag_name = "frame" if target["mid"] == "frame parameter" else "iframe"
+                if target["kind"] == "index":
+                    fl, status = await _resolve_index(base, tag_name, target["right"])
+                else:
+                    fl, status = await _resolve_selector(base, target)
+
+                if status == "fatal":
+                    return "zeuz_failed"
+                if status == "passed":
+                    active_stack.append(fl)
+                    pending.pop(idx)
+                    switched = True
+                    unknown_parent_hops = 0
+                    break
+
+            if switched:
+                continue
+
+            if active_stack:
+                # Walk back to parent (mirrors Selenium switch_to.parent_frame()).
+                active_stack.pop()
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    "No matching frame in current context. Switched to parent frame and retrying",
+                    2,
+                )
+                continue
+
+            if switch_to_default:
+                unresolved = [f"{t['left']}={t['right']}" for t in pending]
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    f"Unable to resolve iframe/frame targets: {', '.join(unresolved)}",
+                    3,
+                )
+                return "zeuz_failed"
+
+            unknown_parent_hops += 1
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                "No matching frame in current context. Switched to parent frame and retrying",
+                2,
+            )
+            if unknown_parent_hops > max_unknown_parent_hops:
+                unresolved = [f"{t['left']}={t['right']}" for t in pending]
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    f"Unable to resolve iframe/frame targets from current starting context: {', '.join(unresolved)}",
+                    3,
+                )
+                return "zeuz_failed"
+
+        frame_locator = active_stack[-1] if active_stack else None
         sr.Set_Shared_Variables("playwright_frame", frame_locator)
         _save_current_playwright_frame(frame_locator)
-        CommonUtil.ExecLog(sModuleInfo, "Switched to iframe", 1)
         return "passed"
 
     except Exception:
@@ -2390,13 +3717,28 @@ async def Handle_Browser_Alert(step_data):
 @logger
 async def drag_and_drop(step_data):
     """
-    Drag and drop an element to a target.
+    Drag and drop a source element to a destination element.
 
-    Example:
-        Field               Sub Field           Value
-        id                  element parameter   drag-item
-        id                  target parameter    drop-zone
-        drag and drop       playwright action   drag and drop
+    Example 1 - Basic (src + dst):
+        Field               Sub Field               Value
+        id                  src element parameter   drag-item
+        id                  dst element parameter   drop-zone
+        drag and drop       playwright action       drag and drop
+
+    Example 2 - With destination offset and hold delay:
+        Field               Sub Field               Value
+        id                  src element parameter   drag-item
+        id                  dst element parameter   drop-zone
+        destination offset  optional parameter      20,0
+        delay               optional parameter      0.5
+        drag and drop       playwright action       drag and drop
+
+    Supported param prefixes (matches Selenium): src / source / dst / destination.
+    Supported scopes: element parameter, parent parameter, child parameter, sibling parameter.
+
+    destination offset: "x,y" as percentage of half the destination's size from its center
+                       (e.g. "20,0" = 20% right of center).
+    delay: seconds to pause between click-and-hold and release (mouse-step pattern).
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global current_page
@@ -2406,33 +3748,109 @@ async def drag_and_drop(step_data):
             CommonUtil.ExecLog(sModuleInfo, "No browser open", 3)
             return "zeuz_failed"
 
-        # Separate source and target parameters
-        source_param = None
-        target_param = None
+        source = []
+        destination = []
+        destination_offset = None
+        delay = None
+        param_dict = {
+            "elementparameter": "element parameter",
+            "parentparameter": "parent parameter",
+            "siblingparameter": "sibling parameter",
+            "childparameter": "child parameter",
+            "optionalparameter": "optional parameter",
+        }
 
         for left, mid, right in step_data:
-            mid_l = mid.strip().lower()
-            if "element parameter" in mid_l:
-                if mid_l.startswith("dst"):
-                    target_param = (left, mid, right)
-                elif mid_l.startswith("src"):
-                    source_param = (left, mid, right)
+            mid_clean = mid.strip().lower()
+            left_l = left.strip().lower()
+            if mid_clean.startswith("src") or mid_clean.startswith("source"):
+                key = mid_clean.replace("src", "", 1) if mid_clean.startswith("src") else mid_clean.replace("source", "", 1)
+                key = key.replace(" ", "")
+                if key in param_dict:
+                    source.append((left, param_dict[key], right))
+            elif mid_clean.startswith("dst") or mid_clean.startswith("destination"):
+                key = mid_clean.replace("dst", "", 1) if mid_clean.startswith("dst") else mid_clean.replace("destination", "", 1)
+                key = key.replace(" ", "")
+                if key in param_dict:
+                    destination.append((left, param_dict[key], right))
+            elif left_l in ("wait", "allow disable", "allow hidden") and mid_clean == "option":
+                source.append((left, mid, right))
+                destination.append((left, mid, right))
+            elif left_l == "destination offset" and mid_clean == "optional parameter":
+                destination_offset = right.strip()
+            elif left_l == "delay" and mid_clean == "optional parameter":
+                try:
+                    delay = float(right.strip())
+                except ValueError:
+                    delay = None
 
-        # Get source element
-        source_locator = await PlaywrightLocator.Get_Element([source_param], current_page, frame_locator=_get_frame_locator())
+        if not source:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                'Please provide source element with "src element parameter", "src parent parameter" etc. Example:\n'
+                "(id, src element parameter, file)",
+                3,
+            )
+            return "zeuz_failed"
+
+        if not destination:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                'Please provide Destination element with "dst element parameter", "dst parent parameter" etc. Example:\n'
+                "(id, dst element parameter, table)",
+                3,
+            )
+            return "zeuz_failed"
+
+        frame = _get_frame_locator()
+        source_locator = await PlaywrightLocator.Get_Element(source, current_page, frame_locator=frame)
         if source_locator == "zeuz_failed":
-            CommonUtil.ExecLog(sModuleInfo, "Source element not found", 3)
+            CommonUtil.ExecLog(sModuleInfo, "Source Element is not found", 3)
             return "zeuz_failed"
 
-        # Get target element
-        target_locator = await PlaywrightLocator.Get_Element([target_param], current_page, frame_locator=_get_frame_locator())
+        target_locator = await PlaywrightLocator.Get_Element(destination, current_page, frame_locator=frame)
         if target_locator == "zeuz_failed":
-            CommonUtil.ExecLog(sModuleInfo, "Target element not found", 3)
+            CommonUtil.ExecLog(sModuleInfo, "Destination Element is not found", 3)
             return "zeuz_failed"
 
-        # Perform drag and drop
-        await source_locator.drag_to(target_locator)
-        CommonUtil.ExecLog(sModuleInfo, "Drag and drop completed", 1)
+        if destination_offset or delay is not None:
+            # Manual mouse-step path so we can apply offset and/or a hold delay.
+            await source_locator.scroll_into_view_if_needed()
+            src_box = await source_locator.bounding_box()
+            await target_locator.scroll_into_view_if_needed()
+            tgt_box = await target_locator.bounding_box()
+            if not src_box or not tgt_box:
+                CommonUtil.ExecLog(sModuleInfo, "Could not compute bounding box for drag and drop", 3)
+                return "zeuz_failed"
+
+            src_x = src_box["x"] + src_box["width"] / 2
+            src_y = src_box["y"] + src_box["height"] / 2
+
+            tgt_center_x = tgt_box["x"] + tgt_box["width"] / 2
+            tgt_center_y = tgt_box["y"] + tgt_box["height"] / 2
+            if destination_offset:
+                try:
+                    parts = destination_offset.replace(" ", "").split(",")
+                    pct_x = float(parts[0])
+                    pct_y = float(parts[1])
+                    tgt_x = tgt_center_x + (tgt_box["width"] / 2.0) * (pct_x / 100.0)
+                    tgt_y = tgt_center_y + (tgt_box["height"] / 2.0) * (pct_y / 100.0)
+                except (ValueError, IndexError):
+                    tgt_x, tgt_y = tgt_center_x, tgt_center_y
+            else:
+                tgt_x, tgt_y = tgt_center_x, tgt_center_y
+
+            await current_page.mouse.move(src_x, src_y)
+            await current_page.mouse.down()
+            # Intermediate steps help frameworks that listen for dragover events.
+            await current_page.mouse.move(tgt_x, tgt_y, steps=10)
+            if delay is not None:
+                await asyncio.sleep(delay)
+            await current_page.mouse.up()
+        else:
+            await source_locator.drag_to(target_locator)
+
+        CommonUtil.ExecLog(sModuleInfo, "Drag and drop completed from source to destination", 1)
         return "passed"
 
     except Exception:
@@ -2574,10 +3992,15 @@ async def execute_javascript(step_data):
         for left, mid, right in step_data:
             left_l = left.strip().lower()
             mid_l = mid.strip().lower()
+            right_v = right.strip()
 
-            if "action" in mid_l:
-                js_code = right
-            elif mid_l == "element parameter":
+            if _is_session_step_row(left, mid):
+                continue
+            if mid_l in ("playwright action", "selenium action"):
+                continue
+            if "javascript" in left_l:
+                js_code = right_v
+            elif _is_element_parameter_mid(mid):
                 has_element = True
             elif mid_l == "save parameter":
                 save_variable = left.strip()
@@ -2744,21 +4167,28 @@ async def resize_window(step_data):
 @logger
 async def Wait_For_Element(step_data):
     """
-    Wait for an element to appear/disappear.
+    Wait for an element to appear/disappear/attach/detach.
 
-    Example 1 - Wait for visible:
+    Example 1 - Wait for visible with explicit timeout (seconds):
+        Field               Sub Field           Value
+        id                  element parameter   results
+        wait for element    playwright action   30
+
+    Example 2 - Wait for hidden:
         Field               Sub Field           Value
         id                  element parameter   loading-spinner
         wait                input parameter     hidden
         wait for element    playwright action   wait for element
 
-    Example 2 - Wait with timeout:
+    Example 3 - Timeout via optional parameter:
         Field               Sub Field           Value
         id                  element parameter   results
         timeout             optional parameter  30
+        state               input parameter     visible
         wait for element    playwright action   wait for element
 
-    States: attached, detached, visible, hidden
+    States: attached, detached, visible, hidden (default: visible)
+    Timeout: seconds (defaults to element_wait shared variable, or 10s)
     """
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
     global current_page
@@ -2769,7 +4199,7 @@ async def Wait_For_Element(step_data):
             return "zeuz_failed"
 
         state = "visible"
-        timeout = None
+        timeout_sec = None
 
         for left, mid, right in step_data:
             left_l = left.strip().lower()
@@ -2779,13 +4209,36 @@ async def Wait_For_Element(step_data):
             if mid_l == "input parameter":
                 if left_l in ("wait", "state"):
                     state = right_v.lower()
-            elif left_l == "wait for element":
-                timeout = int(right_v)
+            elif mid_l == "optional parameter" and left_l == "timeout":
+                try:
+                    timeout_sec = float(right_v)
+                except ValueError:
+                    pass
+            elif "action" in mid_l and left_l == "wait for element":
+                # Selenium-style: action value carries the timeout in seconds.
+                try:
+                    timeout_sec = float(right_v)
+                except ValueError:
+                    pass
 
-        if timeout:
-            await asyncio.sleep(timeout)
+        if timeout_sec is None:
+            default_wait = sr.Get_Shared_Variables("element_wait")
+            if default_wait not in failed_tag_list:
+                try:
+                    timeout_sec = float(default_wait)
+                except (TypeError, ValueError):
+                    timeout_sec = 10
+            else:
+                timeout_sec = 10
 
-        locator = await PlaywrightLocator.Get_Element(step_data, current_page, frame_locator=_get_frame_locator())
+        timeout_ms = int(timeout_sec * 1000)
+
+        locator = await PlaywrightLocator.Get_Element(
+            step_data,
+            current_page,
+            element_wait=timeout_sec,
+            frame_locator=_get_frame_locator(),
+        )
 
         if locator == "zeuz_failed":
             # For hidden/detached states, element not found is actually success
@@ -2795,16 +4248,16 @@ async def Wait_For_Element(step_data):
             CommonUtil.ExecLog(sModuleInfo, "Element not found", 3)
             return "zeuz_failed"
 
-        # wait_options = {"state": state}
-        # if timeout:
-        #     wait_options["timeout"] = timeout
-
-        # locator.wait_for(**wait_options)
-        CommonUtil.ExecLog(sModuleInfo, f"Element reached state: {state}", 1)
-        return "passed"
+        try:
+            await locator.wait_for(state=state, timeout=timeout_ms)
+            CommonUtil.ExecLog(sModuleInfo, f"Element reached state: {state}", 1)
+            return "passed"
+        except PlaywrightTimeoutError:
+            CommonUtil.ExecLog(sModuleInfo, f"Timeout waiting for element to be {state}", 3)
+            return "zeuz_failed"
 
     except PlaywrightTimeoutError:
-        CommonUtil.ExecLog(sModuleInfo, f"Timeout waiting for element to be {state}", 3)
+        CommonUtil.ExecLog(sModuleInfo, "Timeout waiting for element", 3)
         return "zeuz_failed"
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -885,7 +885,7 @@ async def Click_Element(step_data):
                 elif left_l == "timeout":
                     timeout = int(float(right_v) * 1000)
 
-            elif mid_l == "action":
+            elif "action" in mid_l:
                 if "double" in left_l:
                     double_click = True
                 elif "right" in left_l:
@@ -944,7 +944,7 @@ async def Double_Click_Element(step_data):
     modified_step_data = list(step_data)
     # Ensure the action indicates double click
     for i, (left, mid, right) in enumerate(modified_step_data):
-        if mid.strip().lower() == "action":
+        if "action" in mid.strip().lower():
             modified_step_data[i] = ("double click", mid, right)
             break
 
@@ -963,7 +963,7 @@ async def Right_Click_Element(step_data):
     """
     modified_step_data = list(step_data)
     for i, (left, mid, right) in enumerate(modified_step_data):
-        if mid.strip().lower() == "action":
+        if "action" in mid.strip().lower():
             modified_step_data[i] = ("right click", mid, right)
             break
 
@@ -1078,7 +1078,7 @@ async def Enter_Text_In_Text_Box(step_data):
             if mid_l == "optional parameter" and left_l == "session":
                 continue
 
-            if mid_l == "action":
+            if "action" in mid_l:
                 text_value = right  # Don't strip - preserve whitespace
             elif mid_l == "optional parameter":
                 if left_l == "delay":
@@ -1171,7 +1171,7 @@ async def Keystroke_For_Element(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "action":
+            if "action" in mid_l:
                 if left_l == "keystroke keys":
                     keystroke_type = "keys"
                     keystroke_value = right_v
@@ -1320,7 +1320,7 @@ async def Validate_Text(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "action":
+            if "action" in mid_l:
                 if left_l.startswith("**"):
                     partial_match = True
                     case_insensitive = True
@@ -1606,7 +1606,7 @@ async def Navigate(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip().lower()
 
-            if mid_l == "action":
+            if "action" in mid_l:
                 direction = right_v
             elif mid_l == "optional parameter":
                 if left_l == "timeout":
@@ -1830,7 +1830,7 @@ async def Select_Deselect(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "action":
+            if "action" in mid_l:
                 if "deselect" in left_l:
                     is_deselect = True
 
@@ -1916,7 +1916,7 @@ async def check_uncheck(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip().lower()
 
-            if mid_l == "action":
+            if "action" in mid_l:
                 if "uncheck" in left_l or "uncheck" in right_v:
                     action = "uncheck"
                 else:
@@ -2338,7 +2338,7 @@ async def Handle_Browser_Alert(step_data):
             mid_l = mid.strip().lower()
             right_v = right.strip()
 
-            if mid_l == "action":
+            if "action" in mid_l:
                 action = right_v.lower()
             elif mid_l == "input parameter":
                 if left_l in ("prompt text", "text", "send text"):
@@ -2575,7 +2575,7 @@ async def execute_javascript(step_data):
             left_l = left.strip().lower()
             mid_l = mid.strip().lower()
 
-            if mid_l == "action":
+            if "action" in mid_l:
                 js_code = right
             elif mid_l == "element parameter":
                 has_element = True
@@ -2938,7 +2938,7 @@ async def Intercept_Network(step_data):
                     response_body = right_v
                 elif left_l == "response status":
                     response_status = int(right_v)
-            elif mid_l == "action":
+            elif "action" in mid_l:
                 action = right_v.lower()
 
         async def handle_route(route):

--- a/Framework/Built_In_Automation/Web/Playwright/locator.py
+++ b/Framework/Built_In_Automation/Web/Playwright/locator.py
@@ -469,7 +469,12 @@ def _build_shadow_dom_locator(base_locator, params):
                     query_rows.append(parent_param)
                     break
             query_rows.append(shadow_param)
-            host_query = LocateElement.build_css_selector_query(query_rows)
+            if idx == 1:
+                host_query, host_query_type = _build_legacy_query(query_rows)
+                if host_query_type == "xpath":
+                    host_query = _as_playwright_xpath(host_query)
+            else:
+                host_query = LocateElement.build_css_selector_query(query_rows)
             if not host_query:
                 return None
             current = current.locator(host_query)

--- a/Framework/Built_In_Automation/Web/Playwright/locator.py
+++ b/Framework/Built_In_Automation/Web/Playwright/locator.py
@@ -2,471 +2,755 @@
 """
 Playwright Element Locator Module
 
-This module provides element location functionality using Playwright's native
-Locator API while reusing the query building logic from LocateElement.py.
-
-Key Features:
-- Native Playwright Locator API (lazy evaluation, auto-wait)
-- Supports all existing element parameter formats
-- Supports Playwright-native selectors (test-id, role, text, etc.)
-- Preserves Playwright's speed advantage
+This module resolves the standard Zeuz element step-data format to Playwright
+Locator objects. Selenium compatibility is the primary contract: Selenium-style
+element parameters are converted through LocateElement.py's query builder, then
+executed with Playwright's Locator API.
 """
 
-import sys
 import inspect
 import re
+import sys
+from dataclasses import dataclass
+from typing import Any
 
-from Framework.Utilities import CommonUtil
 from Framework.Built_In_Automation.Shared_Resources import (
     BuiltInFunctionSharedResources as sr,
 )
-from Framework.Utilities.CommonUtil import passed_tag_list, failed_tag_list
+from Framework.Utilities import CommonUtil
+from Framework.Utilities.CommonUtil import failed_tag_list
 
 MODULE_NAME = inspect.getmodulename(__file__)
 
 
-async def Get_Element(step_data, page, return_all=False, element_wait=None, frame_locator=None):
+@dataclass
+class LocatorBuildResult:
+    locator: Any
+    query_type: str
+    query: Any
+
+
+async def Get_Element(step_data, page, return_all=False, element_wait=None, frame_locator=None, return_all_elements=False):
     """
-    Get element using Playwright's native Locator API.
+    Resolve Zeuz step-data to a Playwright Locator.
 
-    This function parses the same step_data format as LocateElement.Get_Element()
-    but uses Playwright's Locator API for execution, preserving auto-wait and
-    lazy evaluation benefits.
-
-    Args:
-        step_data: List of (left, mid, right) tuples - standard Zeuz format
-        page: Playwright Page object
-        return_all: If True, return list of all matching ElementHandles
-        element_wait: Override default wait timeout (in seconds)
-        frame_locator: Optional frame locator for iframe context
-
-    Returns:
-        Locator | List[ElementHandle] | "zeuz_failed"
-
-    Example:
-        step_data = [
-            ("id", "element parameter", "submit-btn"),
-            ("click", "playwright action", "click"),
-        ]
-        locator = Get_Element(step_data, page)
-        locator.click()  # Auto-waits for element
+    The returned object intentionally mirrors Selenium LocateElement.Get_Element()
+    semantics where possible: visible elements are preferred by default, multiple
+    matches return the first match unless an index is provided, save/get parameter
+    rows use shared variables, and failures return "zeuz_failed".
     """
+
     sModuleInfo = inspect.currentframe().f_code.co_name + " : " + MODULE_NAME
 
     try:
-        # Parse all parameters from step_data
-        params = _parse_element_params(step_data)
+        if return_all_elements:
+            return_all = True
 
-        # Check for get parameter (retrieve saved element)
-        if params.get('get_parameter'):
-            result = sr.parse_variable(params['get_parameter'])
+        params = _parse_element_params(step_data)
+        if params.get("parse_error"):
+            CommonUtil.ExecLog(sModuleInfo, params["parse_error"], 3)
+            return "zeuz_failed"
+
+        if params.get("get_parameter"):
+            result = sr.parse_variable(params["get_parameter"])
+            result = CommonUtil.ZeuZ_map_code_decoder(result)
             if result not in failed_tag_list:
                 CommonUtil.ExecLog(
                     sModuleInfo,
-                    f"Returning saved element '{params['get_parameter']}' from shared variables",
+                    "Returning saved element '%s' from shared variables" % params["get_parameter"],
                     1,
                 )
                 return result
-            else:
-                CommonUtil.ExecLog(
-                    sModuleInfo,
-                    f"Element '{params['get_parameter']}' not found in shared variables",
-                    3,
-                )
-                return "zeuz_failed"
 
-        # Build the locator
-        locator = _build_locator(page, step_data, params, frame_locator)
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                "Element named '%s' not found in shared variables" % params["get_parameter"],
+                3,
+            )
+            return "zeuz_failed"
 
-        if locator is None:
+        timeout = _resolve_timeout(params, element_wait)
+        build_result = _build_locator(page, step_data, params, frame_locator)
+        if build_result is None or build_result.locator is None:
             CommonUtil.ExecLog(sModuleInfo, "Could not build locator from step data", 3)
             return "zeuz_failed"
 
-        # Set timeout if specified
-        if element_wait is not None:
-            timeout = int(float(element_wait) * 1000)
-        elif params.get('wait') is not None:
-            timeout = int(float(params['wait']) * 1000)
-        else:
-            # Get default from shared variables
-            default_wait = sr.Get_Shared_Variables("element_wait")
-            if default_wait not in failed_tag_list:
-                timeout = int(float(default_wait) * 1000)
-            else:
-                timeout = 10000  # Default 10 seconds
+        CommonUtil.ExecLog(
+            sModuleInfo,
+            f"To locate the Element we used {build_result.query_type}:\n{build_result.query}",
+            5,
+        )
 
-        # Apply visibility filter if not allowing hidden
-        if not params.get('allow_hidden'):
-            # Filter to visible elements only
-            locator = locator.locator("visible=true")
-
-        # Apply index if specified
-        if params.get('index') is not None:
-            index = params['index']
-            locator = locator.nth(index)
-
-        # Log the locator being used
-        CommonUtil.ExecLog(sModuleInfo, f"Playwright locator: {locator}", 5)
-
-        # Save if requested
-        if params.get('save_parameter'):
-            sr.Set_Shared_Variables(params['save_parameter'], locator)
-            CommonUtil.ExecLog(
-                sModuleInfo,
-                f"Saved element to variable '{params['save_parameter']}'",
-                1,
-            )
-
-        # Return all elements if requested
         if return_all:
-            try:
-                elements = await locator.all()
-                CommonUtil.ExecLog(sModuleInfo, f"Found {len(elements)} elements", 1)
-                return elements
-            except Exception as e:
-                CommonUtil.ExecLog(sModuleInfo, f"Error getting all elements: {e}", 3)
-                return "zeuz_failed"
+            result = await _resolve_all(build_result.locator, params, timeout, sModuleInfo)
+            if not result and params.get("text_filter"):
+                result = await _text_filter(step_data, page, frame_locator, params, timeout, return_all)
+        else:
+            result = await _resolve_single(build_result.locator, params, timeout, sModuleInfo)
+            if result == "zeuz_failed" and params.get("text_filter"):
+                result = await _text_filter(step_data, page, frame_locator, params, timeout, return_all)
 
-        # Check if element exists (with timeout)
-        try:
-            count = await locator.count()
-            if count == 0:
-                CommonUtil.ExecLog(sModuleInfo, "No elements found matching locator", 3)
-                return "zeuz_failed"
-            elif count > 1 and params.get('index') is None:
+        if result not in failed_tag_list:
+            if not return_all:
+                await _log_outer_html(result, sModuleInfo)
+            if params.get("save_parameter"):
+                sr.Set_Shared_Variables(params["save_parameter"], result)
                 CommonUtil.ExecLog(
                     sModuleInfo,
-                    f"Found {count} elements. Returning first. Consider using index parameter.",
-                    2,
+                    "Saved element to variable '%s'" % params["save_parameter"],
+                    1,
                 )
-        except Exception:
-            pass  # Count might fail, but locator might still work with auto-wait
+            sr.Set_Shared_Variables("zeuz_element", result)
+            return result
 
-        return locator
+        await _log_frame_hint(page, sModuleInfo)
+        return "zeuz_failed"
 
     except Exception:
         return CommonUtil.Exception_Handler(sys.exc_info())
 
 
 def _parse_element_params(step_data):
-    """
-    Parse element parameters from step data.
+    """Parse Zeuz step-data without losing Selenium locator semantics."""
 
-    Returns dict with:
-        - index: Element index (int or None)
-        - allow_hidden: Whether to include hidden elements (bool)
-        - save_parameter: Variable name to save element (str or None)
-        - get_parameter: Variable name to retrieve element (str or None)
-        - wait: Custom wait timeout in seconds (float or None)
-        - element_params: List of element parameter tuples
-        - parent_params: List of parent parameter tuples
-        - And other parameter lists...
-    """
     params = {
-        'index': None,
-        'allow_hidden': False,
-        'save_parameter': None,
-        'get_parameter': None,
-        'wait': None,
-        'element_params': [],
-        'parent_params': [],
-        'child_params': [],
-        'sibling_params': [],
-        'unique_params': [],
-        'shadow_root_params': [],
+        "index": None,
+        "allow_hidden": False,
+        "allow_disabled": False,
+        "save_parameter": None,
+        "get_parameter": None,
+        "wait": None,
+        "text_filter": False,
+        "parse_error": None,
+        "element_params": [],
+        "parent_params": [],
+        "child_params": [],
+        "sibling_params": [],
+        "preceding_params": [],
+        "following_params": [],
+        "unique_params": [],
+        "shadow_root_params": [],
+        "locator_rows": [],
+        "element_ds": [],
+        "all_rows": [],
     }
 
     for left, mid, right in step_data:
-        left_lower = left.strip().lower()
-        mid_lower = mid.strip().lower()
-        right_stripped = right.strip()
+        left_raw = str(left).strip()
+        mid_raw = str(mid).strip()
+        right_raw = str(right)
+        right_stripped = right_raw.strip()
+        left_lower = left_raw.lower()
+        mid_lower = mid_raw.lower()
+        mid_key = _mid_key(mid_raw)
+        row = (left_raw, mid_raw, right_raw)
+        params["all_rows"].append(row)
 
-        # Save parameter
         if mid_lower == "save parameter":
             if right_stripped != "ignore":
-                params['save_parameter'] = left.strip()
+                params["save_parameter"] = left_raw
+            continue
 
-        # Get parameter
-        elif mid_lower == "get parameter":
+        if mid_lower == "get parameter":
             if right_stripped.startswith("%|") and right_stripped.endswith("|%"):
-                params['get_parameter'] = right_stripped.strip("%").strip("|")
+                params["get_parameter"] = right_stripped.strip("%").strip("|")
+            else:
+                params["parse_error"] = "Use '%| |%' sign at right column to get variable value"
+            continue
 
-        # Optional parameters
-        elif mid_lower == "optional parameter":
-            if left_lower in ("allow hidden", "allow disable"):
-                params['allow_hidden'] = right_stripped.lower() in ("yes", "true", "ok", "1")
+        if mid_lower == "optional parameter":
+            if left_lower == "allow hidden":
+                params["allow_hidden"] = _truthy(right_stripped)
+            elif left_lower == "allow disable":
+                params["allow_disabled"] = _truthy(right_stripped)
             elif left_lower == "wait":
-                params['wait'] = float(right_stripped)
+                try:
+                    params["wait"] = float(right_stripped)
+                except Exception:
+                    params["parse_error"] = "Wait optional parameter must be numeric"
+            elif left_lower == "text filter":
+                params["text_filter"] = _truthy(right_stripped)
+            continue
 
-        # Element parameters
-        elif mid_lower == "element parameter" or "element parameter" in mid_lower:
+        if mid_lower.startswith("sr"):
+            params["shadow_root_params"].append(row)
+            continue
+
+        if mid_key == "uniqueparameter":
+            params["unique_params"].append((left_raw, right_raw))
+            params["locator_rows"].append(row)
+            params["element_ds"].append(row)
+            continue
+
+        if "parent" in mid_key and "parameter" in mid_key:
+            params["parent_params"].append(row)
+            params["locator_rows"].append(row)
+            params["element_ds"].append(row)
+            continue
+
+        if "child" in mid_key and "parameter" in mid_key:
+            params["child_params"].append(row)
+            params["locator_rows"].append(row)
+            params["element_ds"].append(row)
+            continue
+
+        if "sibling" in mid_key and "parameter" in mid_key:
+            params["sibling_params"].append(row)
+            params["locator_rows"].append(row)
+            params["element_ds"].append(row)
+            continue
+
+        if "preceding" in mid_key and "parameter" in mid_key:
+            params["preceding_params"].append(row)
+            params["locator_rows"].append(row)
+            params["element_ds"].append(row)
+            continue
+
+        if "following" in mid_key and "parameter" in mid_key:
+            params["following_params"].append(row)
+            params["locator_rows"].append(row)
+            params["element_ds"].append(row)
+            continue
+
+        if mid_key == "elementparameter":
+            params["locator_rows"].append(row)
+            params["element_ds"].append(row)
             if left_lower == "index":
                 try:
-                    params['index'] = int(right_stripped)
-                except ValueError:
-                    pass
+                    params["index"] = int(right_stripped)
+                except Exception:
+                    params["parse_error"] = "Index = 0 is set"
             else:
-                params['element_params'].append((left.strip(), right_stripped))
+                params["element_params"].append((left_raw, right_raw))
+            continue
 
-        # Unique parameter
-        elif mid_lower == "unique parameter":
-            params['unique_params'].append((left.strip(), right_stripped))
-
-        # Parent parameters (including numbered: parent 2 parameter)
-        elif "parent" in mid_lower and "parameter" in mid_lower:
-            params['parent_params'].append((left.strip(), mid.strip(), right_stripped))
-
-        # Child parameters
-        elif "child" in mid_lower and "parameter" in mid_lower:
-            params['child_params'].append((left.strip(), mid.strip(), right_stripped))
-
-        # Sibling parameters
-        elif "sibling" in mid_lower and "parameter" in mid_lower:
-            params['sibling_params'].append((left.strip(), mid.strip(), right_stripped))
-
-        # Shadow root parameters
-        elif mid_lower.startswith("sr"):
-            params['shadow_root_params'].append((left.strip(), mid.strip(), right_stripped))
+        params["element_ds"].append(row)
 
     return params
 
 
 def _build_locator(page, step_data, params, frame_locator=None):
-    """
-    Build a Playwright Locator from step data.
-
-    Attempts these strategies in order:
-    1. Playwright-native selectors (test-id, role, text, etc.) - fastest
-    2. Direct xpath/css if provided
-    3. Build xpath from element parameters using existing logic
-    
-    Args:
-        page: Playwright Page object
-        step_data: Step data for building xpath
-        params: Parsed element parameters
-        frame_locator: Optional frame locator for iframe context
-    """
-
-    # Use frame locator if provided, otherwise use page
     base_locator = frame_locator if frame_locator else page
 
-    # Strategy 1: Check for Playwright-native selectors (fastest path)
-    for left, right in params['element_params']:
-        left_lower = left.lower()
+    if params["shadow_root_params"]:
+        return _build_shadow_dom_locator(base_locator, params)
 
-        # Test ID selectors
-        if left_lower in ("test-id", "testid", "data-testid", "data-test-id"):
-            return base_locator.get_by_test_id(right)
+    native_locator = _build_native_locator(base_locator, params)
+    if native_locator is not None:
+        return native_locator
 
-        # Role selector
-        if left_lower == "role":
-            # Check if there's a name parameter too
-            name = None
-            for l, r in params['element_params']:
-                if l.lower() in ("name", "role name", "aria-label"):
-                    name = r
-                    break
-            if name:
-                return base_locator.get_by_role(right, name=name)
-            return base_locator.get_by_role(right)
+    if params["unique_params"]:
+        legacy_locator = _build_legacy_locator(base_locator, params)
+        if legacy_locator is not None:
+            return legacy_locator
 
-        # Text selectors
-        if left_lower == "text":
-            return base_locator.get_by_text(right, exact=True)
-        if left_lower == "*text":
-            return base_locator.get_by_text(right, exact=False)
-        if left_lower == "**text":
-            # Case-insensitive partial match
-            return base_locator.get_by_text(re.compile(re.escape(right), re.IGNORECASE))
+    raw_locator = _build_raw_locator(base_locator, step_data)
+    if raw_locator is not None:
+        return raw_locator
 
-        # Label selector
-        if left_lower == "label":
-            return base_locator.get_by_label(right)
-
-        # Placeholder selector
-        if left_lower == "placeholder":
-            return base_locator.get_by_placeholder(right)
-
-        # Alt text selector
-        if left_lower in ("alt", "alt text", "alt-text"):
-            return base_locator.get_by_alt_text(right)
-
-        # Title selector
-        if left_lower == "title" and "parameter" not in params.get('mid', ''):
-            return base_locator.get_by_title(right)
-
-        # Direct xpath
-        if left_lower == "xpath":
-            return base_locator.locator(f"xpath={right}")
-
-        # Direct CSS selector
-        if left_lower in ("css", "css selector", "css_selector"):
-            return base_locator.locator(right)
-
-    # Strategy 2: Check for unique parameters and element parameters
-    for left, right in params['unique_params'] + params['element_params']:
-        left_lower = left.lower()
-
-        if left_lower == "id":
-            return base_locator.locator(f"#{right}")
-        elif left_lower == "name":
-            return base_locator.locator(f"[name='{right}']")
-        elif left_lower == "class":
-            return base_locator.locator(f".{right}")
-        elif left_lower == "tag":
-            return base_locator.locator(right)
-
-    # Strategy 3: Build xpath from element/parent/child parameters
-    xpath = _build_xpath_from_params(step_data, params)
-    if xpath:
-        CommonUtil.ExecLog(
-            "_build_locator",
-            f"Built xpath from parameters: {xpath}",
-            5
-        )
-        return base_locator.locator(f"xpath={xpath}")
-
-    # Strategy 4: Simple element parameters as xpath
-    if params['element_params']:
-        xpath_parts = []
-        tag = "*"
-
-        for left, right in params['element_params']:
-            left_lower = left.lower()
-
-            if left_lower == "tag":
-                tag = right
-            elif left_lower == "id":
-                xpath_parts.append(f"@id='{right}'")
-            elif left_lower == "name":
-                xpath_parts.append(f"@name='{right}'")
-            elif left_lower == "class":
-                xpath_parts.append(f"contains(@class,'{right}')")
-            elif left_lower.startswith("*"):
-                # Partial match
-                attr = left_lower[1:]
-                xpath_parts.append(f"contains(@{attr},'{right}')")
-            elif left_lower.startswith("**"):
-                # Case-insensitive partial match
-                attr = left_lower[2:]
-                xpath_parts.append(
-                    f"contains(translate(@{attr},'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),'{right.lower()}')"
-                )
-            elif left_lower not in ("index", "text", "*text", "**text"):
-                # Generic attribute
-                xpath_parts.append(f"@{left}='{right}'")
-
-        if xpath_parts:
-            xpath = f"//{tag}[{' and '.join(xpath_parts)}]"
-            return base_locator.locator(f"xpath={xpath}")
-        elif tag != "*":
-            return base_locator.locator(tag)
+    legacy_locator = _build_legacy_locator(base_locator, params)
+    if legacy_locator is not None:
+        return legacy_locator
 
     return None
 
 
-def _build_xpath_from_params(step_data, params):
-    """
-    Build complex xpath from element/parent/child/sibling parameters.
+def _build_native_locator(base_locator, params):
+    """Support explicit Playwright-only selector aliases without overriding Selenium semantics."""
 
-    This reuses the logic from LocateElement._construct_query() but simplified
-    for the most common cases.
-    """
+    if _has_relationship_params(params) or params["unique_params"] or len(params["element_params"]) != 1:
+        return None
+
+    left, right = params["element_params"][0]
+    left_lower = left.lower()
+    if left_lower in ("test-id", "testid"):
+        return LocatorBuildResult(base_locator.get_by_test_id(right), "playwright test-id", right)
+    return None
+
+
+def _build_raw_locator(base_locator, step_data):
+    xpath_rows = []
+    css_rows = []
+    for left, mid, right in step_data:
+        left_lower = str(left).strip().lower()
+        mid_key = _mid_key(str(mid))
+        if mid_key != "elementparameter":
+            continue
+        if left_lower == "xpath":
+            xpath_rows.append(str(right).strip())
+        elif left_lower in ("css", "css selector", "css_selector"):
+            css_rows.append(str(right).strip())
+
+    if xpath_rows and not css_rows:
+        query = xpath_rows[0]
+        return LocatorBuildResult(base_locator.locator(_as_playwright_xpath(query)), "xpath", query)
+    if css_rows and not xpath_rows:
+        query = css_rows[0]
+        return LocatorBuildResult(base_locator.locator(query), "css", query)
+    return None
+
+
+def _build_legacy_locator(base_locator, params):
+    query, query_type = _build_legacy_query(params["locator_rows"])
+    if not query or not query_type:
+        return None
+
+    if query_type == "unique":
+        locator = _build_unique_locator(base_locator, query[0], query[1])
+        return LocatorBuildResult(locator, query_type, query)
+    if query_type == "css":
+        return LocatorBuildResult(base_locator.locator(query), query_type, query)
+    if query_type == "xpath":
+        return LocatorBuildResult(base_locator.locator(_as_playwright_xpath(query)), query_type, query)
+    return None
+
+
+def _build_legacy_query(locator_rows):
+    if not locator_rows:
+        return None, None
+
     try:
-        # Import the existing query builder for complex cases
         from Framework.Built_In_Automation.Shared_Resources import LocateElement
 
-        # Filter step_data to only include element-related rows
-        element_rows = []
-        for left, mid, right in step_data:
-            mid_lower = mid.strip().lower().replace(" ", "")
-            if any(x in mid_lower for x in [
-                "elementparameter", "parentparameter", "childparameter",
-                "siblingparameter", "uniqueparameter", "precedingparameter",
-                "followingparameter"
-            ]):
-                element_rows.append((left, mid, right))
+        original_driver_type = getattr(LocateElement, "driver_type", None)
+        LocateElement.driver_type = "selenium"
+        try:
+            return LocateElement._construct_query(locator_rows)
+        finally:
+            LocateElement.driver_type = original_driver_type
+    except Exception as e:
+        CommonUtil.ExecLog("_build_legacy_query", f"Error building Selenium-compatible query: {e}", 2)
+        return None, None
 
-        if not element_rows:
+
+def _build_unique_locator(base_locator, unique_key, unique_value):
+    key = str(unique_key).strip().lower()
+    value = str(unique_value).strip()
+
+    if key in ("accessibility id", "accessibility-id", "content-desc", "content desc"):
+        return base_locator.locator(_as_playwright_xpath(f"//*[@aria-label={_xpath_literal(value)}]"))
+    if key == "id":
+        return base_locator.locator(_as_playwright_xpath(f"//*[@id={_xpath_literal(value)}]"))
+    if key == "name":
+        return base_locator.locator(_as_playwright_xpath(f"//*[@name={_xpath_literal(value)}]"))
+    if key == "class":
+        klass = _xpath_literal(f" {value} ")
+        return base_locator.locator(
+            _as_playwright_xpath(f"//*[contains(concat(' ', normalize-space(@class), ' '), {klass})]")
+        )
+    if key == "tag":
+        return base_locator.locator(_as_playwright_xpath(f"//{value}"))
+    if key == "css":
+        return base_locator.locator(value)
+    if key == "xpath":
+        return base_locator.locator(_as_playwright_xpath(value))
+    if key == "text":
+        return base_locator.locator(_as_playwright_xpath(f"//*[text()={_xpath_literal(value)}]"))
+    if key == "*text":
+        return base_locator.locator(_as_playwright_xpath(f"//*[contains(text(),{_xpath_literal(value)})]"))
+    if key.startswith("**"):
+        attr = key[2:]
+        return base_locator.locator(
+            _as_playwright_xpath(
+                "//*[contains(translate(@%s,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz'),%s)]"
+                % (attr, _xpath_literal(value.lower()))
+            )
+        )
+    if key.startswith("*"):
+        attr = key[1:]
+        return base_locator.locator(_as_playwright_xpath(f"//*[contains(@{attr},{_xpath_literal(value)})]"))
+    return base_locator.locator(_as_playwright_xpath(f"//*[@{key}={_xpath_literal(value)}]"))
+
+
+def _build_shadow_dom_locator(base_locator, params):
+    try:
+        from Framework.Built_In_Automation.Shared_Resources import LocateElement
+
+        shadow_root_params = []
+        parent_params = []
+
+        for left, mid, right in params["shadow_root_params"]:
+            left_lower = left.strip().lower()
+            if "text" in left_lower:
+                CommonUtil.ExecLog(
+                    "_build_shadow_dom_locator",
+                    "Shadow DOM access requires attribute/tag/css selectors; text selectors are not supported",
+                    3,
+                )
+                return None
+
+            words = mid.strip().lower().split()
+            if len(words) < 3 or len(words) > 4:
+                CommonUtil.ExecLog("_build_shadow_dom_locator", f"Invalid shadow root parameter format: {mid}", 3)
+                return None
+            idx = int(words[1]) if len(words) == 4 else 1
+            param = " ".join(words[-2:])
+            normalized_row = [left, param, right]
+
+            if "parent" in param:
+                parent_params.append((idx, normalized_row))
+            elif "element" in param:
+                shadow_root_params.append((idx, normalized_row))
+            else:
+                CommonUtil.ExecLog(
+                    "_build_shadow_dom_locator",
+                    "Only shadow root parent parameter and element parameter rows are supported",
+                    3,
+                )
+                return None
+
+        parent_indices = [idx for idx, _ in parent_params]
+        shadow_indices = [idx for idx, _ in shadow_root_params]
+        if len(parent_indices) != len(set(parent_indices)) or len(shadow_indices) != len(set(shadow_indices)):
+            CommonUtil.ExecLog("_build_shadow_dom_locator", "Duplicate shadow root indices found", 3)
             return None
 
-        # Use existing query builder
-        # Temporarily set driver_type to selenium for xpath generation
-        original_driver_type = getattr(LocateElement, 'driver_type', None)
-        LocateElement.driver_type = "selenium"
+        parent_params.sort(key=lambda item: item[0])
+        shadow_root_params.sort(key=lambda item: item[0])
+        current = base_locator
+        query_parts = []
 
-        try:
-            xpath, query_type = LocateElement._construct_query(element_rows)
-            if xpath and query_type in ("xpath", "css"):
-                return xpath
-        finally:
-            if original_driver_type is not None:
-                LocateElement.driver_type = original_driver_type
+        for idx, shadow_param in shadow_root_params:
+            query_rows = []
+            for parent_idx, parent_param in parent_params:
+                if parent_idx == idx:
+                    query_rows.append(parent_param)
+                    break
+            query_rows.append(shadow_param)
+            host_query = LocateElement.build_css_selector_query(query_rows)
+            if not host_query:
+                return None
+            current = current.locator(host_query)
+            host_index = _index_from_rows([shadow_param]) or 0
+            current = current.nth(host_index)
+            query_parts.append(host_query)
 
-    except Exception as e:
+        element_query = LocateElement.build_css_selector_query([list(row) for row in params["element_ds"]])
+        if not element_query:
+            return None
+        query_parts.append(element_query)
+        return LocatorBuildResult(current.locator(element_query), "shadow css", " >> ".join(query_parts))
+    except Exception:
+        return CommonUtil.Exception_Handler(sys.exc_info())
+
+
+async def _resolve_single(locator, params, timeout, sModuleInfo):
+    effective_locator = _effective_locator(locator, params)
+    state = "attached" if params.get("allow_hidden") else "visible"
+
+    if not await _wait_for_locator(effective_locator, state, timeout):
+        await _log_no_match(locator, params, sModuleInfo)
+        return "zeuz_failed"
+
+    count = await _safe_count(effective_locator)
+    total_count = await _safe_count(locator)
+    hidden_count = max(total_count - count, 0) if not params.get("allow_hidden") else 0
+
+    index = params.get("index")
+    if count == 0:
+        await _log_no_match(locator, params, sModuleInfo)
+        return "zeuz_failed"
+
+    if index is None:
+        if count > 1:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"Found {count} displayed elements. Returning the first displayed element only. Consider providing index",
+                2,
+            )
+        elif hidden_count > 0:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"Found {hidden_count} hidden elements and {count} displayed element. Returning the displayed element only",
+                2,
+            )
+        return _first_locator(effective_locator)
+
+    if count == 1:
+        if index not in (-1, 0):
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                f"Found {count} element but provided index {index} is out of range. Returning the only element",
+                2,
+            )
+        return _first_locator(effective_locator)
+
+    resolved_index = index if index >= 0 else count + index
+    if 0 <= resolved_index < count:
         CommonUtil.ExecLog(
-            "_build_xpath_from_params",
-            f"Error building xpath: {e}",
-            2
+            sModuleInfo,
+            f"Found {count} elements. Returning the element of index {index}",
+            1,
         )
+        return effective_locator.nth(resolved_index)
 
+    CommonUtil.ExecLog(sModuleInfo, f"Found {count} elements. Index {index} exceeds the number of elements found", 3)
+    return "zeuz_failed"
+
+
+async def _resolve_all(locator, params, timeout, sModuleInfo):
+    effective_locator = _effective_locator(locator, params)
+    state = "attached" if params.get("allow_hidden") else "visible"
+    if not await _wait_for_locator(effective_locator, state, timeout):
+        CommonUtil.ExecLog(sModuleInfo, "Found 0 elements", 3)
+        return []
+
+    all_locators = await effective_locator.all()
+    total_count = await _safe_count(locator)
+    displayed_count = len(all_locators)
+    hidden_count = max(total_count - displayed_count, 0) if not params.get("allow_hidden") else 0
+
+    if params.get("allow_hidden"):
+        CommonUtil.ExecLog(sModuleInfo, f"Found {displayed_count} elements. Returning all of them", 1)
+    else:
+        CommonUtil.ExecLog(
+            sModuleInfo,
+            f"Found {hidden_count} hidden elements and {displayed_count} displayed elements. Returning displayed elements only",
+            1,
+        )
+    return all_locators
+
+
+async def _text_filter(step_data, page, frame_locator, original_params, timeout, return_all):
+    sModuleInfo = "text_filter : " + MODULE_NAME
+
+    if original_params["sibling_params"]:
+        return "zeuz_failed"
+
+    filters = []
+    temp_step_data = []
+    for left, mid, right in step_data:
+        left_lower = str(left).strip().lower()
+        mid_lower = str(mid).strip().lower()
+        if left_lower.replace("*", "") == "text" and mid_lower == "element parameter":
+            filters.append((left_lower, str(right)))
+        else:
+            temp_step_data.append((left, mid, right))
+
+    if not filters:
+        return "zeuz_failed"
+
+    temp_params = _parse_element_params(temp_step_data)
+    temp_params["allow_hidden"] = original_params.get("allow_hidden", False)
+    build_result = _build_locator(page, temp_step_data, temp_params, frame_locator)
+    if build_result is None:
+        return "zeuz_failed"
+
+    CommonUtil.ExecLog(sModuleInfo, "No Element found. Now we are trying to handle &nbsp; and <space>", 1)
+    CommonUtil.ExecLog(sModuleInfo, f"To locate the Element we used {build_result.query_type}:\n{build_result.query}", 5)
+
+    candidate_locator = _effective_locator(build_result.locator, temp_params)
+    state = "attached" if temp_params.get("allow_hidden") else "visible"
+    if not await _wait_for_locator(candidate_locator, state, timeout):
+        return "zeuz_failed"
+
+    candidates = await candidate_locator.all()
+    matches = []
+    similar_texts = []
+    for candidate in candidates:
+        try:
+            text = await candidate.text_content() or ""
+        except Exception:
+            continue
+        if _matches_text_filters(text, filters):
+            matches.append(candidate)
+        elif _similar_text(text, filters) and text not in similar_texts:
+            similar_texts.append(text)
+
+    if return_all:
+        CommonUtil.ExecLog(sModuleInfo, f"Returning {len(matches)} elements after applying Text Filter", 1)
+        return matches
+
+    if not matches:
+        CommonUtil.ExecLog(sModuleInfo, "Found no element after applying Text Filter", 3)
+        if similar_texts:
+            CommonUtil.ExecLog(sModuleInfo, f"These are the similar texts found in the HTML: {str(similar_texts)[1:-1]}", 3)
+        return "zeuz_failed"
+
+    index = original_params.get("index") or 0
+    resolved_index = index if index >= 0 else len(matches) + index
+    if not 0 <= resolved_index < len(matches):
+        CommonUtil.ExecLog(sModuleInfo, f"Found {len(matches)} elements after applying Text Filter. Index out of range", 3)
+        return "zeuz_failed"
+
+    CommonUtil.ExecLog(sModuleInfo, f"Found {len(matches)} elements after applying Text Filter. Returning index {index}", 1)
+    return matches[resolved_index]
+
+
+async def wait_for_element(step_data, page, state="visible", timeout=None):
+    """Wait for an element to reach a Playwright state."""
+
+    sModuleInfo = "wait_for_element"
+
+    try:
+        params = _parse_element_params(step_data)
+        if timeout is None:
+            timeout = _resolve_timeout(params, None)
+        build_result = _build_locator(page, step_data, params)
+        if build_result is None:
+            CommonUtil.ExecLog(sModuleInfo, "Could not build locator from step data", 3)
+            return "zeuz_failed"
+
+        locator = build_result.locator
+        if state == "visible" and not params.get("allow_hidden"):
+            locator = _effective_locator(locator, params)
+        if params.get("index") is not None:
+            locator = locator.nth(params["index"])
+        else:
+            locator = _first_locator(locator)
+
+        await locator.wait_for(state=state, timeout=timeout)
+        CommonUtil.ExecLog(sModuleInfo, f"Element reached state: {state}", 1)
+        return "passed"
+    except Exception as e:
+        CommonUtil.ExecLog(sModuleInfo, f"Wait for element failed: {e}", 3)
+        return "zeuz_failed"
+
+
+def _effective_locator(locator, params):
+    if params.get("allow_hidden"):
+        return locator
+    return locator.filter(visible=True)
+
+
+async def _wait_for_locator(locator, state, timeout):
+    try:
+        await _first_locator(locator).wait_for(state=state, timeout=timeout)
+        return True
+    except Exception:
+        return False
+
+
+async def _safe_count(locator):
+    try:
+        return await locator.count()
+    except Exception:
+        return 0
+
+
+async def _log_no_match(locator, params, sModuleInfo):
+    total_count = await _safe_count(locator)
+    if total_count > 0 and not params.get("allow_hidden"):
+        CommonUtil.ExecLog(
+            sModuleInfo,
+            "Found %s hidden elements and no displayed elements. Nothing to return.\n" % total_count
+            + 'To get hidden elements add a row ("allow hidden", "optional parameter", "yes")',
+            3,
+        )
+    else:
+        CommonUtil.ExecLog(sModuleInfo, "No elements found matching locator", 3)
+
+
+async def _log_outer_html(locator, sModuleInfo):
+    try:
+        outer_html = await locator.evaluate("el => el.outerHTML")
+        CommonUtil.ExecLog(sModuleInfo, _opening_tag(outer_html), 5)
+    except Exception:
+        pass
+
+
+async def _log_frame_hint(page, sModuleInfo):
+    try:
+        if await page.locator("iframe").count() > 0:
+            CommonUtil.ExecLog(sModuleInfo, 'You have Iframes in your Webpage. Try switching Iframe with "Switch Iframe" action', 3)
+        elif await page.locator("frame").count() > 0:
+            CommonUtil.ExecLog(sModuleInfo, 'You have Frames in your Webpage. Try switching Frame with "Switch Iframe" action', 3)
+    except Exception:
+        pass
+
+
+def _resolve_timeout(params, element_wait):
+    if element_wait is not None:
+        return int(float(element_wait) * 1000)
+    if params.get("wait") is not None:
+        return int(float(params["wait"]) * 1000)
+    default_wait = sr.Get_Shared_Variables("element_wait")
+    if default_wait not in failed_tag_list:
+        return int(float(default_wait) * 1000)
+    return 10000
+
+
+def _first_locator(locator):
+    first = getattr(locator, "first")
+    return first() if callable(first) else first
+
+
+def _has_relationship_params(params):
+    return any(
+        params[key]
+        for key in (
+            "parent_params",
+            "child_params",
+            "sibling_params",
+            "preceding_params",
+            "following_params",
+            "shadow_root_params",
+        )
+    )
+
+
+def _index_from_rows(rows):
+    for left, mid, right in rows:
+        if str(left).strip().lower() == "index" and str(mid).strip().lower() == "element parameter":
+            try:
+                return int(str(right).strip())
+            except Exception:
+                return None
     return None
 
 
-def handle_shadow_dom(page, shadow_params, element_params):
-    """
-    Handle Shadow DOM element location.
+def _matches_text_filters(text, filters):
+    normalized_text = text.replace("\xa0", " ")
+    for left, value in filters:
+        normalized_value = value.replace("\xa0", " ")
+        if left.startswith("**") and normalized_value.lower() in normalized_text.lower():
+            return True
+        if left.startswith("*") and normalized_value in normalized_text:
+            return True
+        if normalized_value == normalized_text:
+            return True
+    return False
 
-    Playwright supports automatic shadow DOM piercing with the >> selector.
 
-    Args:
-        page: Playwright Page object
-        shadow_params: List of shadow root parameters
-        element_params: Final element parameters
+def _similar_text(text, filters):
+    collapsed_text = re.sub(r"\s+", "", text.lower().replace("\xa0", ""))
+    for _, value in filters:
+        if value.lower().replace("\xa0", "").replace(" ", "") in collapsed_text:
+            return True
+    return False
 
-    Returns:
-        Locator for element inside shadow DOM
-    """
-    sModuleInfo = "handle_shadow_dom"
 
-    try:
-        # Build a chain of selectors using Playwright's shadow-piercing >>
-        # Sort shadow params by their index (sr 1, sr 2, etc.)
-        sorted_params = sorted(shadow_params, key=lambda x: _extract_sr_index(x[1]))
+def _opening_tag(outer_html):
+    i, quote_count = 0, 0
+    for i in range(len(outer_html)):
+        if outer_html[i] == '"':
+            quote_count += 1
+        if outer_html[i] == ">" and quote_count % 2 == 0:
+            break
+    return outer_html[: i + 1]
 
-        selector_parts = []
 
-        for left, mid, right in sorted_params:
-            left_lower = left.lower()
-            if left_lower == "tag":
-                selector_parts.append(right)
-            elif left_lower == "id":
-                selector_parts.append(f"#{right}")
-            elif left_lower == "class":
-                selector_parts.append(f".{right}")
-            else:
-                selector_parts.append(f"[{left}='{right}']")
+def _as_playwright_xpath(query):
+    query = str(query).strip()
+    return query if query.startswith("xpath=") else f"xpath={query}"
 
-        # Add final element
-        for left, right in element_params:
-            left_lower = left.lower()
-            if left_lower == "tag":
-                selector_parts.append(right)
-            elif left_lower == "id":
-                selector_parts.append(f"#{right}")
-            elif left_lower == "class":
-                selector_parts.append(f".{right}")
-            else:
-                selector_parts.append(f"[{left}='{right}']")
 
-        # Join with >> for shadow DOM piercing
-        full_selector = " >> ".join(selector_parts)
-        CommonUtil.ExecLog(sModuleInfo, f"Shadow DOM selector: {full_selector}", 5)
+def _xpath_literal(value):
+    value = str(value)
+    if '"' not in value:
+        return f'"{value}"'
+    if "'" not in value:
+        return f"'{value}'"
+    parts = value.split('"')
+    return "concat(%s)" % ", '\"', ".join(f'"{part}"' for part in parts)
 
-        return page.locator(full_selector)
 
-    except Exception:
-        return CommonUtil.Exception_Handler(sys.exc_info())
+def _mid_key(mid):
+    return str(mid).replace(" ", "").lower()
+
+
+def _truthy(value):
+    return str(value).strip().lower() in ("yes", "true", "ok", "1", "enable")
 
 
 def _extract_sr_index(mid_value):
@@ -481,37 +765,11 @@ def _extract_sr_index(mid_value):
     return 1
 
 
-async def wait_for_element(step_data, page, state="visible", timeout=None):
-    """
-    Wait for element to reach a specific state.
-
-    Args:
-        step_data: Standard step data format
-        page: Playwright Page object
-        state: One of "attached", "detached", "visible", "hidden"
-        timeout: Timeout in milliseconds
-
-    Returns:
-        "passed" | "zeuz_failed"
-    """
-    sModuleInfo = "wait_for_element"
-
-    try:
-        locator = await Get_Element(step_data, page)
-        if locator == "zeuz_failed":
-            return "zeuz_failed"
-
-        if timeout is None:
-            default_wait = sr.Get_Shared_Variables("element_wait")
-            if default_wait not in failed_tag_list:
-                timeout = int(float(default_wait) * 1000)
-            else:
-                timeout = 10000
-
-        locator.wait_for(state=state, timeout=timeout)
-        CommonUtil.ExecLog(sModuleInfo, f"Element reached state: {state}", 1)
-        return "passed"
-
-    except Exception as e:
-        CommonUtil.ExecLog(sModuleInfo, f"Wait for element failed: {e}", 3)
-        return "zeuz_failed"
+# Backwards-compatible alias for code that imported the old helper directly.
+def handle_shadow_dom(page, shadow_params, element_params):
+    params = {
+        "shadow_root_params": shadow_params,
+        "element_ds": [(left, "element parameter", right) for left, right in element_params],
+    }
+    result = _build_shadow_dom_locator(page, params)
+    return result.locator if result not in failed_tag_list and result is not None else "zeuz_failed"

--- a/Framework/Built_In_Automation/Web/Playwright/locator.py
+++ b/Framework/Built_In_Automation/Web/Playwright/locator.py
@@ -30,9 +30,40 @@ class LocatorBuildResult:
     query: Any
 
 
-async def Get_Element(step_data, page, return_all=False, element_wait=None, frame_locator=None, return_all_elements=False):
+async def Get_Element(
+    step_data,
+    page,
+    return_all=False,
+    element_wait=None,
+    frame_locator=None,
+    parent_locator=None,
+    return_all_elements=False,
+):
     """
     Resolve Zeuz step-data to a Playwright Locator.
+
+    This function parses the same step_data format as LocateElement.Get_Element()
+    but uses Playwright's Locator API for execution, preserving auto-wait and
+    lazy evaluation benefits.
+
+    Args:
+        step_data: List of (left, mid, right) tuples - standard Zeuz format
+        page: Playwright Page object
+        return_all: If True, return list of all matching ElementHandles
+        element_wait: Override default wait timeout (in seconds)
+        frame_locator: Optional frame locator for iframe context
+        parent_locator: Optional Locator to scope the search under a container element
+
+    Returns:
+        Locator | List[ElementHandle] | "zeuz_failed"
+
+    Example:
+        step_data = [
+            ("id", "element parameter", "submit-btn"),
+            ("click", "playwright action", "click"),
+        ]
+        locator = Get_Element(step_data, page)
+        locator.click()  # Auto-waits for element
 
     The returned object intentionally mirrors Selenium LocateElement.Get_Element()
     semantics where possible: visible elements are preferred by default, multiple
@@ -70,7 +101,7 @@ async def Get_Element(step_data, page, return_all=False, element_wait=None, fram
             return "zeuz_failed"
 
         timeout = _resolve_timeout(params, element_wait)
-        build_result = _build_locator(page, step_data, params, frame_locator)
+        build_result = _build_locator(page, step_data, params, frame_locator, parent_locator)
         if build_result is None or build_result.locator is None:
             CommonUtil.ExecLog(sModuleInfo, "Could not build locator from step data", 3)
             return "zeuz_failed"
@@ -158,7 +189,8 @@ def _parse_element_params(step_data):
                 params["parse_error"] = "Use '%| |%' sign at right column to get variable value"
             continue
 
-        if mid_lower == "optional parameter":
+        # Optional parameters
+        if mid_lower in ("optional parameter", "option"):
             if left_lower == "allow hidden":
                 params["allow_hidden"] = _truthy(right_stripped)
             elif left_lower == "allow disable":
@@ -229,8 +261,28 @@ def _parse_element_params(step_data):
     return params
 
 
-def _build_locator(page, step_data, params, frame_locator=None):
-    base_locator = frame_locator if frame_locator else page
+def _build_locator(page, step_data, params, frame_locator=None, parent_locator=None):
+    """
+    Build a Playwright Locator from step data.
+
+    Attempts these strategies in order:
+    1. Playwright-native selectors (test-id, role, text, etc.) - fastest
+    2. Direct xpath/css if provided
+    3. Build xpath from element parameters using existing logic
+    
+    Args:
+        page: Playwright Page object
+        step_data: Step data for building xpath
+        params: Parsed element parameters
+        frame_locator: Optional frame locator for iframe context
+        parent_locator: Scope search within this locator (overrides frame when both set).
+    """
+
+    # Parent scope wins, then iframe, then full page.
+    if parent_locator is not None:
+        base_locator = parent_locator
+    else:
+        base_locator = frame_locator if frame_locator else page
 
     if params["shadow_root_params"]:
         return _build_shadow_dom_locator(base_locator, params)

--- a/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Selenium/BuiltInFunctions.py
@@ -1856,7 +1856,7 @@ def Enter_Text_In_Text_Box(step_data):
             # Skip session parameter - already handled above
             if left == "session" and mid == "optional parameter":
                 continue
-            if mid == "action":
+            if "action" in mid:
                 text_value = right
             elif left == "delay":
                 delay = float(right.strip())

--- a/Framework/Built_In_Automation/Web/utils.py
+++ b/Framework/Built_In_Automation/Web/utils.py
@@ -1,6 +1,9 @@
 import hashlib
+import inspect
 import socket
+import sys
 
+from Framework.Utilities import CommonUtil
 from Framework.Built_In_Automation.Shared_Resources import (
     BuiltInFunctionSharedResources as sr,
 )
@@ -135,3 +138,228 @@ def get_browser_session(session_name: str) -> dict:
     
     browser_sessions = get_browser_sessions()
     return browser_sessions.get(session_name, {})
+
+
+def _find_session_name_by_object(key: str, value) -> str | None:
+    """Return the session name that owns the given browser object."""
+
+    if value is None:
+        return None
+
+    for name, session in get_browser_sessions().items():
+        if isinstance(session, dict) and session.get(key) is value:
+            return name
+
+    return None
+
+
+def _resolve_browser_session_name(step_data=None) -> str | None:
+    """Resolve the browser session to hydrate for custom Python code."""
+
+    session_name = extract_session_name(step_data)
+    if session_name:
+        return session_name
+
+    active_type = sr.shared_variables.get("active_web_driver_type")
+    if active_type == "playwright":
+        session_name = _find_session_name_by_object(
+            "playwright_page", sr.shared_variables.get("playwright_page")
+        )
+        if session_name:
+            return session_name
+    elif active_type == "selenium":
+        session_name = _find_session_name_by_object(
+            "selenium_driver", sr.shared_variables.get("selenium_driver")
+        )
+        if session_name:
+            return session_name
+
+    session_name = _find_session_name_by_object(
+        "playwright_page", sr.shared_variables.get("playwright_page")
+    )
+    if session_name:
+        return session_name
+
+    session_name = _find_session_name_by_object(
+        "selenium_driver", sr.shared_variables.get("selenium_driver")
+    )
+    if session_name:
+        return session_name
+
+    if "default" in get_browser_sessions():
+        return "default"
+
+    return None
+
+
+def _set_browser_shared_variables(session: dict):
+    """Hydrate canonical browser shared variables from a session."""
+
+    if session.get("selenium_driver") is not None:
+        sr.Set_Shared_Variables(
+            "selenium_driver", session["selenium_driver"], print_variable=False
+        )
+    if session.get("playwright_page") is not None:
+        sr.Set_Shared_Variables(
+            "playwright_page", session["playwright_page"], print_variable=False
+        )
+    if session.get("playwright_context") is not None:
+        sr.Set_Shared_Variables(
+            "playwright_context", session["playwright_context"], print_variable=False
+        )
+    if session.get("playwright_browser") is not None:
+        sr.Set_Shared_Variables(
+            "playwright_browser", session["playwright_browser"], print_variable=False
+        )
+    if session.get("playwright_frame") is not None:
+        sr.Set_Shared_Variables(
+            "playwright_frame", session["playwright_frame"], print_variable=False
+        )
+
+
+def _restore_active_web_driver_type(previous_active_type):
+    if previous_active_type:
+        sr.Set_Shared_Variables(
+            "active_web_driver_type",
+            previous_active_type,
+            print_variable=False,
+        )
+    else:
+        sr.Remove_From_Shared_Variables("active_web_driver_type")
+
+
+def _align_selenium_to_playwright_page(session: dict):
+    selenium_driver = session.get("selenium_driver")
+    playwright_page = session.get("playwright_page")
+    target_url = getattr(playwright_page, "url", None)
+
+    if not selenium_driver or not target_url:
+        return
+
+    try:
+        current_handle = selenium_driver.current_window_handle
+        for handle in selenium_driver.window_handles:
+            selenium_driver.switch_to.window(handle)
+            if selenium_driver.current_url == target_url:
+                return
+        selenium_driver.switch_to.window(current_handle)
+    except Exception:
+        pass
+
+
+async def _align_playwright_to_selenium_window(session_name: str, session: dict):
+    selenium_driver = session.get("selenium_driver")
+    playwright_context = session.get("playwright_context")
+
+    if not selenium_driver or not playwright_context:
+        return
+
+    try:
+        target_url = selenium_driver.current_url
+    except Exception:
+        return
+
+    if not target_url:
+        return
+
+    try:
+        for page in playwright_context.pages:
+            if page.url == target_url:
+                session["playwright_page"] = page
+                sessions = get_browser_sessions()
+                if session_name in sessions:
+                    sessions[session_name]["playwright_page"] = page
+                    sr.Set_Shared_Variables(
+                        "browser_sessions", sessions, print_variable=False
+                    )
+                return
+    except Exception:
+        pass
+
+
+async def hydrate_browser_compatibility_globals(step_data=None):
+    """
+    Populate canonical Selenium/Playwright shared variables for custom Python.
+
+    This uses the existing lazy CDP bridge in the Selenium and Playwright action
+    modules. It intentionally does not create user-facing convenience aliases.
+    """
+
+    sModuleInfo = "hydrate_browser_compatibility_globals : Web.utils"
+    session_name = _resolve_browser_session_name(step_data)
+    if not session_name:
+        return "passed"
+
+    session = get_browser_session(session_name)
+    if not isinstance(session, dict) or not session:
+        CommonUtil.ExecLog(
+            sModuleInfo, f"Browser session '{session_name}' not found", 2
+        )
+        return "zeuz_failed"
+
+    previous_active_type = sr.shared_variables.get("active_web_driver_type")
+
+    try:
+        if session.get("playwright_page") and not session.get("selenium_driver"):
+            if session.get("selenium_cdp_supported") is False:
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    f"Selenium compatibility is only supported for Chromium Playwright sessions: {session_name}",
+                    2,
+                )
+            else:
+                from Framework.Built_In_Automation.Web.Selenium import (
+                    BuiltInFunctions as SeleniumBuiltInFunctions,
+                )
+
+                result = SeleniumBuiltInFunctions._ensure_selenium_session(
+                    session_name, session
+                )
+                if inspect.isawaitable(result):
+                    result = await result
+                if result in ("zeuz_failed", "failed", False):
+                    CommonUtil.ExecLog(
+                        sModuleInfo,
+                        f"Could not hydrate Selenium globals for browser session '{session_name}'",
+                        2,
+                    )
+
+        session = get_browser_session(session_name)
+        if session.get("selenium_driver") and not session.get("playwright_page"):
+            if session.get("remote_debugging_port"):
+                from Framework.Built_In_Automation.Web.Playwright import (
+                    BuiltInFunctions as PlaywrightBuiltInFunctions,
+                )
+
+                result = await PlaywrightBuiltInFunctions._ensure_playwright_session(
+                    session_name, session
+                )
+                if result in ("zeuz_failed", "failed", False):
+                    CommonUtil.ExecLog(
+                        sModuleInfo,
+                        f"Could not hydrate Playwright globals for browser session '{session_name}'",
+                        2,
+                    )
+            else:
+                CommonUtil.ExecLog(
+                    sModuleInfo,
+                    f"Playwright compatibility requires a remote debugging port for session '{session_name}'",
+                    2,
+                )
+
+        session = get_browser_session(session_name)
+        if isinstance(session, dict):
+            _align_selenium_to_playwright_page(session)
+            await _align_playwright_to_selenium_window(session_name, session)
+
+        if isinstance(session, dict):
+            _set_browser_shared_variables(session)
+
+        _restore_active_web_driver_type(previous_active_type)
+
+        CommonUtil.set_screenshot_vars(sr.Shared_Variable_Export())
+        return "passed"
+    except Exception:
+        CommonUtil.Exception_Handler(sys.exc_info())
+        _restore_active_web_driver_type(previous_active_type)
+        return "zeuz_failed"

--- a/tests/test_browser_sessions.py
+++ b/tests/test_browser_sessions.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from Framework.Built_In_Automation.Shared_Resources import (
     BuiltInFunctionSharedResources as sr,
@@ -77,9 +77,11 @@ def test_playwright_session_activation_selects_page_and_frame():
         playwright_frame=frame,
     )
 
-    result = playwright_bif._activate_browser_session_for_action(
-        [("session", "optional parameter", "buyer")],
-        "Hover_Over_Element",
+    result = asyncio.run(
+        playwright_bif._activate_browser_session_for_action(
+            [("session", "optional parameter", "buyer")],
+            "Hover_Over_Element",
+        )
     )
 
     assert result == "passed"
@@ -92,9 +94,11 @@ def test_playwright_session_activation_selects_page_and_frame():
 
 
 def test_playwright_missing_explicit_session_fails_non_create_action():
-    result = playwright_bif._activate_browser_session_for_action(
-        [("session", "optional parameter", "missing")],
-        "Validate_Text",
+    result = asyncio.run(
+        playwright_bif._activate_browser_session_for_action(
+            [("session", "optional parameter", "missing")],
+            "Validate_Text",
+        )
     )
 
     assert result == "zeuz_failed"
@@ -138,6 +142,7 @@ def test_playwright_switch_iframe_uses_index_parameter_after_default_reset():
     indexed_frame_locator = MagicMock()
     frame_locator.nth.return_value = indexed_frame_locator
     page = MagicMock()
+    page.locator.return_value.count = AsyncMock(return_value=2)
     page.frame_locator.return_value = frame_locator
     playwright_bif.current_page = page
     playwright_bif.current_page_id = "default"

--- a/tests/test_playwright_actions_parity.py
+++ b/tests/test_playwright_actions_parity.py
@@ -1,0 +1,141 @@
+import asyncio
+
+from Framework.Built_In_Automation.Shared_Resources import (
+    BuiltInFunctionSharedResources as sr,
+)
+from Framework.Built_In_Automation.Web.Playwright import BuiltInFunctions as pw
+
+
+class FakePage:
+    def __init__(self):
+        self.url = "https://example.test/current"
+        self.viewport_size = {"width": 1000, "height": 800}
+        self.evaluated = []
+
+    async def evaluate(self, script, arg=None):
+        self.evaluated.append((script, arg))
+        return "page-result"
+
+    async def set_viewport_size(self, size):
+        self.viewport_size = size
+
+
+class FakeLocator:
+    def __init__(self, text=""):
+        self.text = text
+        self.evaluated = []
+        self.files = None
+
+    async def inner_text(self):
+        return self.text
+
+    async def text_content(self):
+        return self.text
+
+    async def evaluate(self, script, arg=None):
+        self.evaluated.append((script, arg))
+        return "locator-result"
+
+    async def set_input_files(self, file_path):
+        self.files = file_path
+
+    async def bounding_box(self):
+        return {"x": 10, "y": 20, "width": 200, "height": 30}
+
+
+def setup_function():
+    sr.shared_variables.clear()
+    pw.current_page = FakePage()
+    pw.context = None
+    pw.browser = None
+    pw.current_page_id = "default"
+
+
+def test_get_current_url_saves_to_selenium_action_row_value():
+    result = pw.Get_Current_URL(
+        [("get current url", "selenium action", "current_url")]
+    )
+
+    assert result == "passed"
+    assert sr.Get_Shared_Variables("current_url") == "https://example.test/current"
+
+
+def test_validate_full_text_uses_visible_line_matching(monkeypatch):
+    locator = FakeLocator("Header\nSuccess\nFooter")
+
+    async def fake_get_element(*args, **kwargs):
+        return locator
+
+    monkeypatch.setattr(pw.PlaywrightLocator, "Get_Element", fake_get_element)
+
+    result = asyncio.run(
+        pw.Validate_Text(
+            [
+                ("id", "element parameter", "message"),
+                ("validate full text", "selenium action", "Success"),
+            ]
+        )
+    )
+
+    assert result == "passed"
+
+
+def test_upload_file_accepts_selenium_action_row_path(monkeypatch, tmp_path):
+    upload_file = tmp_path / "upload.txt"
+    upload_file.write_text("data")
+    locator = FakeLocator()
+
+    async def fake_get_element(*args, **kwargs):
+        return locator
+
+    monkeypatch.setattr(pw.PlaywrightLocator, "Get_Element", fake_get_element)
+
+    result = asyncio.run(
+        pw.upload_file(
+            [
+                ("id", "element parameter", "file-input"),
+                ("upload file", "selenium action", str(upload_file)),
+            ]
+        )
+    )
+
+    assert result == "passed"
+    assert locator.files == str(upload_file)
+
+
+def test_execute_javascript_supports_variable_and_elem(monkeypatch):
+    locator = FakeLocator()
+
+    async def fake_get_element(*args, **kwargs):
+        return locator
+
+    monkeypatch.setattr(pw.PlaywrightLocator, "Get_Element", fake_get_element)
+
+    result = asyncio.run(
+        pw.execute_javascript(
+            [
+                ("id", "element parameter", "target"),
+                ("variable", "optional parameter", "js_result"),
+                ("execute javascript", "selenium action", "return $elem.textContent"),
+            ]
+        )
+    )
+
+    assert result == "passed"
+    assert sr.Get_Shared_Variables("js_result") == "locator-result"
+    assert "return el.textContent" in locator.evaluated[0][0]
+
+
+def test_resize_window_accepts_selenium_element_parameter_rows():
+    result = asyncio.run(
+        pw.resize_window(
+            [
+                ("width", "element parameter", "50%"),
+                ("height", "element parameter", "25%"),
+                ("resize window", "selenium action", "resize window"),
+            ]
+        )
+    )
+
+    assert result == "passed"
+    assert pw.current_page.viewport_size == {"width": 500, "height": 200}

--- a/tests/test_playwright_locator.py
+++ b/tests/test_playwright_locator.py
@@ -1,0 +1,249 @@
+import asyncio
+
+from Framework.Built_In_Automation.Shared_Resources import (
+    BuiltInFunctionSharedResources as sr,
+)
+from Framework.Built_In_Automation.Web.Playwright import locator as playwright_locator
+
+
+class FakeLocator:
+    def __init__(self, name="root", count=1, total_count=None, texts=None, text=""):
+        self.name = name
+        self._count = count
+        self._total_count = count if total_count is None else total_count
+        self.texts = texts
+        self.text = text
+        self.filtered = False
+        self.nth_index = None
+        self.wait_calls = []
+        self.queries = []
+
+    def locator(self, query):
+        self.queries.append(query)
+        return FakeLocator(f"{self.name}.locator({query})", self._count, self._total_count, self.texts, self.text)
+
+    def filter(self, **kwargs):
+        filtered = FakeLocator(f"{self.name}.filter", self._count, self._total_count, self.texts, self.text)
+        filtered.filtered = kwargs.get("visible") is True
+        return filtered
+
+    @property
+    def first(self):
+        text = self.texts[0] if self.texts else self.text
+        first = FakeLocator(f"{self.name}.first", min(self._count, 1), self._total_count, self.texts, text)
+        first.filtered = self.filtered
+        return first
+
+    def nth(self, index):
+        text = self.texts[index] if self.texts and 0 <= index < len(self.texts) else self.text
+        nth = FakeLocator(f"{self.name}.nth({index})", 1, self._total_count, self.texts, text)
+        nth.nth_index = index
+        nth.filtered = self.filtered
+        return nth
+
+    async def wait_for(self, state="visible", timeout=None):
+        self.wait_calls.append((state, timeout))
+        if self._count == 0:
+            raise TimeoutError("not found")
+
+    async def count(self):
+        return self._count
+
+    async def all(self):
+        return [self.nth(i) for i in range(self._count)]
+
+    async def text_content(self):
+        return self.text
+
+    async def evaluate(self, script):
+        return '<button id="save">Save</button>'
+
+
+class FakePage:
+    def __init__(self, locator_result):
+        self.locator_result = locator_result
+        self.queries = []
+
+    def locator(self, query):
+        self.queries.append(query)
+        return self.locator_result
+
+
+def setup_function():
+    sr.shared_variables.clear()
+    sr.Set_Shared_Variables("element_wait", 1)
+
+
+def test_parser_preserves_numbered_relationship_and_shadow_rows():
+    params = playwright_locator._parse_element_params(
+        [
+            ("tag", "element parameter", "button"),
+            ("class", "parent 2 parameter", "panel"),
+            ("id", "sr 1 element parameter", "shadow-host"),
+            ("wait", "optional parameter", "3"),
+        ]
+    )
+
+    assert params["element_params"] == [("tag", "button")]
+    assert params["parent_params"] == [("class", "parent 2 parameter", "panel")]
+    assert params["shadow_root_params"] == [("id", "sr 1 element parameter", "shadow-host")]
+    assert ("id", "sr 1 element parameter", "shadow-host") not in params["locator_rows"]
+    assert params["wait"] == 3
+
+
+def test_legacy_query_matches_selenium_for_tag_and_text():
+    params = playwright_locator._parse_element_params(
+        [
+            ("tag", "element parameter", "button"),
+            ("text", "element parameter", "Save"),
+        ]
+    )
+
+    query, query_type = playwright_locator._build_legacy_query(params["locator_rows"])
+
+    assert query_type == "xpath"
+    assert query == '//button[text()="Save"]'
+
+
+def test_legacy_query_preserves_parent_child_sibling_rows():
+    params = playwright_locator._parse_element_params(
+        [
+            ("tag", "element parameter", "input"),
+            ("type", "element parameter", "password"),
+            ("id", "parent parameter", "login-form"),
+            ("text", "child parameter", "Required"),
+        ]
+    )
+
+    query, query_type = playwright_locator._build_legacy_query(params["locator_rows"])
+
+    assert query_type == "xpath"
+    assert "input" in query
+    assert '[@type="password"]' in query
+    assert 'ancestor::*[@id="login-form"]' in query
+    assert 'descendant::*[text()="Required"]' in query
+
+
+def test_resolve_single_returns_first_for_multiple_matches():
+    params = playwright_locator._parse_element_params(
+        [("tag", "element parameter", "button")]
+    )
+    root = FakeLocator(count=3)
+
+    result = asyncio.run(playwright_locator._resolve_single(root, params, 1000, "test"))
+
+    assert isinstance(result, FakeLocator)
+    assert result.name.endswith(".filter.first")
+    assert result.filtered is True
+
+
+def test_resolve_single_honors_index_after_visibility_filter():
+    params = playwright_locator._parse_element_params(
+        [
+            ("tag", "element parameter", "button"),
+            ("index", "element parameter", "2"),
+        ]
+    )
+    root = FakeLocator(count=4)
+
+    result = asyncio.run(playwright_locator._resolve_single(root, params, 1000, "test"))
+
+    assert isinstance(result, FakeLocator)
+    assert result.nth_index == 2
+    assert result.filtered is True
+
+
+def test_get_element_uses_legacy_xpath_and_saves_shared_variables():
+    fake_locator = FakeLocator(count=2)
+    page = FakePage(fake_locator)
+
+    result = asyncio.run(
+        playwright_locator.Get_Element(
+            [
+                ("tag", "element parameter", "button"),
+                ("text", "element parameter", "Save"),
+                ("saved_button", "save parameter", "yes"),
+            ],
+            page,
+        )
+    )
+
+    assert result.name.endswith(".filter.first")
+    assert page.queries == ['xpath=//button[text()="Save"]']
+    assert sr.Get_Shared_Variables("saved_button") is result
+    assert sr.Get_Shared_Variables("zeuz_element") is result
+
+
+def test_get_element_accepts_selenium_return_all_elements_keyword():
+    fake_locator = FakeLocator(count=2)
+    page = FakePage(fake_locator)
+
+    result = asyncio.run(
+        playwright_locator.Get_Element(
+            [("tag", "element parameter", "button")],
+            page,
+            return_all_elements=True,
+        )
+    )
+
+    assert len(result) == 2
+    assert page.queries == ["xpath=//button"]
+
+
+def test_unique_parameter_takes_precedence_over_raw_xpath_like_selenium():
+    fake_locator = FakeLocator(count=1)
+    page = FakePage(fake_locator)
+
+    result = playwright_locator._build_locator(
+        page,
+        [
+            ("id", "unique parameter", "primary"),
+            ("xpath", "element parameter", "//button[@id='secondary']"),
+        ],
+        playwright_locator._parse_element_params(
+            [
+                ("id", "unique parameter", "primary"),
+                ("xpath", "element parameter", "//button[@id='secondary']"),
+            ]
+        ),
+    )
+
+    assert result.query_type == "unique"
+    assert page.queries == ['xpath=//*[@id="primary"]']
+
+
+def test_shadow_dom_builder_uses_sr_rows_and_css_query_chain():
+    params = playwright_locator._parse_element_params(
+        [
+            ("id", "sr 1 element parameter", "host"),
+            ("tag", "element parameter", "button"),
+            ("data-action", "element parameter", "save"),
+        ]
+    )
+    page = FakePage(FakeLocator())
+
+    result = playwright_locator._build_shadow_dom_locator(page, params)
+
+    assert result.query_type == "shadow css"
+    assert result.query == '*[id="host"] >> button[data-action="save"]'
+
+
+def test_text_filter_matches_normalized_nbsp_text():
+    page = FakePage(FakeLocator(count=2, texts=["Hello\xa0World", "Other"]))
+
+    result = asyncio.run(
+        playwright_locator._text_filter(
+            [
+                ("tag", "element parameter", "div"),
+                ("text", "element parameter", "Hello World"),
+            ],
+            page,
+            None,
+            {"allow_hidden": False, "index": None, "sibling_params": []},
+            1000,
+            False,
+        )
+    )
+
+    assert isinstance(result, FakeLocator)
+    assert result.text == "Hello\xa0World"

--- a/tests/test_playwright_locator.py
+++ b/tests/test_playwright_locator.py
@@ -55,6 +55,9 @@ class FakeLocator:
     async def text_content(self):
         return self.text
 
+    async def inner_text(self):
+        return self.text
+
     async def evaluate(self, script):
         return '<button id="save">Save</button>'
 
@@ -225,7 +228,78 @@ def test_shadow_dom_builder_uses_sr_rows_and_css_query_chain():
     result = playwright_locator._build_shadow_dom_locator(page, params)
 
     assert result.query_type == "shadow css"
-    assert result.query == '*[id="host"] >> button[data-action="save"]'
+    assert result.query == 'xpath=//*[@id="host"] >> button[data-action="save"]'
+
+
+def test_raw_xpath_ignores_additional_constraints_like_selenium():
+    fake_locator = FakeLocator(count=1)
+    page = FakePage(fake_locator)
+    params = playwright_locator._parse_element_params(
+        [
+            ("xpath", "element parameter", "//button[@id='save']"),
+            ("text", "element parameter", "Ignored"),
+        ]
+    )
+
+    result = playwright_locator._build_locator(page, params["all_rows"], params)
+
+    assert result.query_type == "xpath"
+    assert page.queries == ["xpath=//button[@id='save']"]
+
+
+def test_allow_hidden_does_not_apply_visible_filter():
+    params = playwright_locator._parse_element_params(
+        [
+            ("tag", "element parameter", "button"),
+            ("allow hidden", "optional parameter", "yes"),
+        ]
+    )
+    root = FakeLocator(count=2)
+
+    result = asyncio.run(playwright_locator._resolve_single(root, params, 1000, "test"))
+
+    assert isinstance(result, FakeLocator)
+    assert result.filtered is False
+
+
+def test_resolve_single_negative_index():
+    params = playwright_locator._parse_element_params(
+        [
+            ("tag", "element parameter", "button"),
+            ("index", "element parameter", "-1"),
+        ]
+    )
+    root = FakeLocator(count=4)
+
+    result = asyncio.run(playwright_locator._resolve_single(root, params, 1000, "test"))
+
+    assert isinstance(result, FakeLocator)
+    assert result.nth_index == 3
+
+
+def test_shadow_dom_rejects_duplicate_sr_indices():
+    params = playwright_locator._parse_element_params(
+        [
+            ("id", "sr 1 element parameter", "host-a"),
+            ("class", "sr 1 element parameter", "host-b"),
+            ("tag", "element parameter", "button"),
+        ]
+    )
+    page = FakePage(FakeLocator())
+
+    assert playwright_locator._build_shadow_dom_locator(page, params) is None
+
+
+def test_shadow_dom_rejects_text_selector():
+    params = playwright_locator._parse_element_params(
+        [
+            ("text", "sr 1 element parameter", "Host"),
+            ("tag", "element parameter", "button"),
+        ]
+    )
+    page = FakePage(FakeLocator())
+
+    assert playwright_locator._build_shadow_dom_locator(page, params) is None
 
 
 def test_text_filter_matches_normalized_nbsp_text():


### PR DESCRIPTION
## Goal

Bring Playwright web actions closer to Selenium action behavior so existing Selenium-style step data works with Playwright.

## Playwright actions changelog

1. `open browser`
   - Reads browser choice from existing dependency settings when available.
   - Accepts Selenium-style driver/session aliases.
   - Enables downloads in the Playwright browser context.

2. `go to link`
   - Accepts Selenium-style session and driver id aliases.
   - Keeps existing wait, timeout, and resolution handling for Playwright navigation.

3. `go to link v2`
   - Adds a Playwright compatibility wrapper for Selenium v2 navigation rows.
   - Maps common v2 settings to the normal Playwright navigation flow.

4. `tear down browser` / `teardown`
   - Accepts legacy driver id style session fields.
   - Keeps Playwright session cleanup aligned with Selenium-style step data.

5. `switch browser`
   - Defaults to the `default` session when no id is provided.
   - Accepts `driver id`, `driverid`, `driver tag`, `page id`, and `session`.

6. `click and download`
   - Adds a Playwright implementation.
   - Clicks the target element, waits for the download, and saves it to the requested path or download folder.

7. `keystroke keys` / `keystroke chars`
   - Adds Selenium key aliases such as `CMD`, `PLUS`, `MINUS`, and `DASH`.
   - Adds paste handling that uses clipboard text and dispatches input/change events.

8. `validate full text` / `validate partial text`
   - Uses visible text lines instead of comparing one full text block.
   - Supports Selenium-style `ignore case` behavior.

9. `save attribute`
   - Reads visible text with Playwright `inner_text()` for closer Selenium parity.
   - Keeps Selenium-style save parameter parsing.

10. `get element info`
   - Saves to the variable from the action row when provided.
   - Stores Selenium-shaped `size` and `location` data.

11. `get current url`
   - Saves the URL to the variable named in the action row.
   - Keeps existing Playwright save parameter support.

12. `scroll`
   - Accepts scroll direction from the action row.
   - Supports Selenium-style `pixels` rows.
   - Scrolls the element when element parameters are provided.

13. `scroll to element` / `scroll element to top`
   - Restores Selenium default additional scroll behavior.
   - Supports direction hints in the additional scroll row name.

14. `select by visible text`, `select by value`, `select by index`
   - Keeps existing Playwright selection behavior.
   - Improves parsing compatibility with Selenium action rows.

15. `deselect all`, `deselect by visible text`, `deselect by value`, `deselect by index`
   - Adds JavaScript-based deselect behavior for Playwright.
   - Fixes `deselect all` and `deselect by index` handling.

16. `check uncheck`
   - Skips elements that are already in the requested state.
   - Falls back to click or JavaScript click for custom checkbox-like controls.

17. `check uncheck all`
   - Adds a Playwright implementation.
   - Finds target elements under a parent and checks or unchecks each one.

18. `slider bar`
   - Adds a Playwright implementation.
   - Clicks the slider at the requested percentage position.

19. `close tab`
   - Supports Selenium-style `tabs` lists.
   - Switches to the tab on the left after closing the current tab.

20. `handle alert`
   - Supports Selenium shorthand such as `get text = var` and `send text = value`.
   - Supports accept/reject aliases.
   - Fails when no alert appears within the timeout.

21. `take screenshot web`
   - Uses the configured screenshot folder when no path is provided.
   - Supports action-row filename formats.
   - Saves `zeuz_screenshot` like Selenium.

22. `execute javascript`
   - Supports Selenium-style `variable` optional parameter.
   - Supports `return ...` page scripts.
   - Supports `$elem` replacement for element scripts.

23. `upload file`
   - Accepts the file path from the Selenium-style action row.
   - Keeps existing Playwright `file path` input parameter support.

24. `copy image into browser`
   - Adds a Playwright implementation.
   - Copies PNG or SVG images into the browser clipboard when browser clipboard APIs allow it.

25. `resize window`
   - Accepts Selenium-style `width` and `height` rows as element parameters.
   - Keeps existing Playwright viewport resize behavior.

26. `capture network log`
   - Adds a Playwright implementation.
   - Captures request and response metadata and saves filtered results to a variable.

27. `extract table data`
   - Saves to the variable named in the action row.
   - Applies Selenium-style row and column filters.

28. Element locating used by Playwright actions
   - Improves shadow DOM locator behavior.
   - Adds regression coverage for raw XPath, hidden elements, negative indexes, and shadow DOM edge cases.

29. Tests
   - Adds focused Playwright action parity tests.
   - Extends locator and browser session tests for the updated behavior.