### PR TITLE
Prevent ZeuZ AI browser extension's DOM collection from changing browser state

### DIFF
--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1252,7 +1252,7 @@ def send_dom_variables():
                         if attr_name.startswith('__'):
                             continue
                         try:
-                            attr_value = getattr(var_value, attr_name)
+                            attr_value = inspect.getattr_static(var_value, attr_name)
                             dir_[attr_name] = str(type(attr_value))
                         except Exception:  # ignore getattr errors
                             pass

--- a/Framework/MainDriverApi.py
+++ b/Framework/MainDriverApi.py
@@ -1171,7 +1171,8 @@ def run_test_case(
             pass
 
         if CommonUtil.debug_status:
-            send_dom_variables()
+            if ConfigModule.get_config_value("Inspector", "ai_plugin").strip().lower() in CommonUtil.affirmative_words:
+                send_dom_variables()
         else:
             CommonUtil.Join_Thread_and_Return_Result("screenshot")
             if _auto_teardown_after_test_case():


### PR DESCRIPTION
## Bug description
- Running the same TC in debug mode could fail even though it completed successfully in deploy mode.
- Page was automatically scrolling down in debug.

## Root cause
- Debug mode calls `send_dom_variables()` for AI context collection.
- `send_dom_variables()` used `getattr()` while inspecting non-JSON shared variables.
- `getattr()` can execute Selenium `WebElement` properties (e.g. `WebElement.location_when_scrolled_into_view`) and change browser scroll state.

## Solution
- Only call `send_dom_variables()` when `Inspector.ai_plugin` is enabled.
- Use `inspect.getattr_static()` while collecting non-JSON attribute type metadata so properties are not executed.