### PR TITLE
Fix pyatspi getStateSet compatibility across library versions

### DIFF
--- a/Framework/Built_In_Automation/Desktop/Linux/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Desktop/Linux/BuiltInFunctions.py
@@ -836,7 +836,10 @@ def get_extended_info(accessible):
     except Exception:
         pass
     try:
-        state_set = accessible.getStateSet()
+        try:
+            state_set = accessible.getStateSet()
+        except Exception:
+            state_set = accessible.get_state_set()
         states = [pyatspi.stateToString(s) or "" for s in state_set.getStates()]
         if states:
             info_str += f' states="{",".join(states)}"'


### PR DESCRIPTION
## Summary
- Add fallback to `get_state_set()` when `getStateSet()` is unavailable in `get_extended_info`, since some pyatspi versions use snake_case naming.

## Test plan
- [ ] Verify Linux desktop automation state extraction works on environments with older/newer pyatspi versions