### PR TITLE
Fix Save Attribute appium action conflicting with element save-parameter handling

### DIFF
--- a/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Mobile/CrossPlatform/Appium/BuiltInFunctions.py
@@ -5050,16 +5050,28 @@ def Save_Attribute_appium(step_data):
         return "passed"
 
     try:
-        Element = LocateElement.Get_Element(step_data, appium_driver)
-        if Element == "zeuz_failed":
-            CommonUtil.ExecLog(sModuleInfo, "Unable to locate your element with given data.", 3)
-            return "zeuz_failed"
-
+        variable_name = None
+        new_ds = []
         for each_step_data_item in step_data:
             if "save parameter" in each_step_data_item[1]:
                 variable_name = each_step_data_item[2]
                 attribute_name = each_step_data_item[0].strip().lower()
-                break
+            else:
+                new_ds.append(each_step_data_item)
+
+        if variable_name is None:
+            CommonUtil.ExecLog(
+                sModuleInfo,
+                "Variable name should be mentioned. Example: (text, save parameter, var_name)",
+                3,
+            )
+            return "zeuz_failed"
+
+        Element = LocateElement.Get_Element(new_ds, appium_driver)
+        if Element == "zeuz_failed":
+            CommonUtil.ExecLog(sModuleInfo, "Unable to locate your element with given data.", 3)
+            return "zeuz_failed"
+
         try:
             if attribute_name == "text":
                 attribute_value = Element.text


### PR DESCRIPTION
## Summary
- `LocateElement.Get_Element()` has its own generic "save the located element to a variable" feature, keyed off the `"save parameter"` sub-field, where it treats the **Field** column as the variable name.
- `Save_Attribute_appium` reuses that same `"save parameter"` tag with the opposite convention (Field = attribute to read, Value = destination variable) and was passing the raw `step_data` straight into `Get_Element`.
- Result: for a step like `content-desc | save parameter | testing`, `Get_Element` tried to save the located element under the variable name `content-desc`, which fails Python identifier validation (hyphen) and logs a confusing `'content-desc' is not a valid variable name` error — even though the actual attribute save into `testing` still worked.
- Fixed by stripping the `"save parameter"` row out of the data set before calling `Get_Element`, mirroring the existing (correct) pattern already used in `Save_Attribute` for Selenium and Playwright.
- Also added a `None` check on `variable_name` so the action fails cleanly with a clear message instead of crashing if no `"save parameter"` row is present.

## Test plan
- [ ] Run an Appium "save attribute" step with a hyphenated attribute name (e.g. `content-desc`) and confirm no spurious "invalid variable name" error is logged, and the variable is saved correctly.
- [ ] Run an Appium "save attribute" step with a non-hyphenated attribute name (e.g. `text`) and confirm behavior is unchanged.
- [ ] Confirm omitting the `"save parameter"` row now fails with the "Variable name should be mentioned" message instead of raising an unhandled exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)