### PR TITLE
Fix Selenium-routed Playwright wait parity

### DIFF
--- a/Framework/Built_In_Automation/Shared_Resources/LocateElement.py
+++ b/Framework/Built_In_Automation/Shared_Resources/LocateElement.py
@@ -4,6 +4,7 @@
 Created on Jun 21, 2017
 @author: Built_In_Automation Solutionz Inc.
 """
+import asyncio
 import sys, time, re
 import inspect
 import traceback
@@ -19,6 +20,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from appium.webdriver.common.appiumby import AppiumBy
 import selenium
+from selenium.webdriver.remote import webelement as selenium_webelement
 from xml.etree.ElementTree import tostring, fromstring
 global WebDriver_Wait
 WebDriver_Wait = 2
@@ -1280,9 +1282,19 @@ def _get_xpath_or_css_element(element_query, css_xpath,data_set, index_number=No
                 else:
                     return "zeuz_failed"
 
+                if (
+                    _has_selenium_action_row(data_set)
+                    and Filter != "allow hidden"
+                    and not return_all_elements
+                    and index_number is None
+                    and not _has_text_filter(data_set)
+                    and not _has_explicit_wait_state(data_set)
+                ):
+                    return await _first_selenium_displayed_locator(locator, element_wait)
+
                 effective_locator = locator if Filter == "allow hidden" else locator.filter(visible=True)
                 if (
-                    _has_action_row(data_set, "playwright action")
+                    _has_browser_action_row(data_set)
                     and not return_all_elements
                     and index_number is None
                     and not _has_text_filter(data_set)
@@ -1429,8 +1441,60 @@ def _first_locator(locator):
     return first() if callable(first) else first
 
 
-def _has_action_row(data_set, action_subfield):
-    return any(action_subfield in str(mid).strip().lower() for _left, mid, _right in data_set)
+def _has_browser_action_row(data_set):
+    return any(
+        str(mid).strip().lower() in ("action", "selenium action", "playwright action")
+        for _left, mid, _right in data_set
+    )
+
+
+def _has_selenium_action_row(data_set):
+    return any(
+        str(mid).strip().lower() == "selenium action"
+        for _left, mid, _right in data_set
+    )
+
+
+def _has_explicit_wait_state(data_set):
+    return any(
+        str(left).strip().lower() in ("wait", "state")
+        and str(mid).strip().lower() == "input parameter"
+        for left, mid, _right in data_set
+    )
+
+
+def _selenium_is_displayed_expression():
+    if selenium_webelement.isDisplayed_js is None:
+        selenium_webelement._load_js()
+    return f"(element) => ({selenium_webelement.isDisplayed_js}).apply(null, [element])"
+
+
+async def _first_selenium_displayed_locator(locator, element_wait):
+    end = time.monotonic() + float(element_wait)
+    expression = _selenium_is_displayed_expression()
+
+    while True:
+        remaining = end - time.monotonic()
+        if remaining <= 0:
+            return "zeuz_failed"
+
+        try:
+            count = await locator.count()
+        except Exception:
+            count = 0
+
+        for index in range(count):
+            candidate = locator.nth(index)
+            try:
+                if await candidate.evaluate(
+                    expression,
+                    timeout=min(remaining * 1000, 250),
+                ):
+                    return candidate
+            except Exception:
+                pass
+
+        await asyncio.sleep(min(0.1, remaining))
 
 
 def _has_text_filter(data_set):

--- a/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
+++ b/Framework/Built_In_Automation/Web/Playwright/BuiltInFunctions.py
@@ -5259,6 +5259,7 @@ async def Wait_For_Element(step_data):
         explicit_state = None
         timeout_sec = None
         allow_hidden = False
+        selenium_compatibility = False
 
         for left, mid, right in step_data:
             left_l = left.strip().lower()
@@ -5276,6 +5277,7 @@ async def Wait_For_Element(step_data):
             elif mid_l in ("optional parameter", "option") and left_l == "allow hidden":
                 allow_hidden = right_v.lower() in ("yes", "true", "ok", "enable", "enabled", "1")
             elif "action" in mid_l and left_l in ("wait", "wait disable", "wait for element"):
+                selenium_compatibility = mid_l == "selenium action"
                 if left_l == "wait disable":
                     inferred_state = "hidden"
                 # Selenium-style: action value carries the timeout in seconds.
@@ -5302,6 +5304,33 @@ async def Wait_For_Element(step_data):
                 timeout_sec = 10
 
         timeout_ms = int(timeout_sec * 1000)
+
+        if selenium_compatibility and explicit_state is None and not allow_hidden:
+            if state == "visible":
+                locator = await PlaywrightLocator.Get_Element(
+                    step_data,
+                    current_page,
+                    element_wait=timeout_sec,
+                )
+                if locator == "zeuz_failed":
+                    CommonUtil.ExecLog(sModuleInfo, "Timeout waiting for element to be visible", 3)
+                    return "zeuz_failed"
+                CommonUtil.ExecLog(sModuleInfo, "Element reached Selenium-compatible state: visible", 1)
+                return "passed"
+
+            end = time.monotonic() + timeout_sec
+            while time.monotonic() < end:
+                locator = await PlaywrightLocator.Get_Element(
+                    step_data,
+                    current_page,
+                    element_wait=min(0.2, end - time.monotonic()),
+                )
+                if locator == "zeuz_failed":
+                    CommonUtil.ExecLog(sModuleInfo, "Element reached Selenium-compatible state: hidden", 1)
+                    return "passed"
+                await asyncio.sleep(min(0.1, max(end - time.monotonic(), 0)))
+            CommonUtil.ExecLog(sModuleInfo, "Timeout waiting for element to be hidden", 3)
+            return "zeuz_failed"
 
         try:
             locator = await PlaywrightLocator.Get_Element(step_data, current_page)

--- a/tests/test_playwright_actions_parity.py
+++ b/tests/test_playwright_actions_parity.py
@@ -9,12 +9,18 @@ from Framework.Built_In_Automation.Web.Playwright import BuiltInFunctions as pw
 
 
 class FakePage:
-    def __init__(self):
+    def __init__(self, locator_result=None):
         self.url = "https://example.test/current"
         self.viewport_size = {"width": 1000, "height": 800}
         self.evaluated = []
         self.keyboard = FakeKeyboard()
         self.mouse = FakeMouse()
+        self.locator_result = locator_result
+        self.queries = []
+
+    def locator(self, query):
+        self.queries.append(query)
+        return self.locator_result
 
     async def evaluate(self, script, arg=None):
         self.evaluated.append((script, arg))
@@ -47,12 +53,13 @@ class FakeMouse:
 
 
 class FakeLocator:
-    def __init__(self, text=""):
+    def __init__(self, text="", selenium_displayed=True):
         self.text = text
         self.evaluated = []
         self.files = None
         self.calls = []
         self.wait_calls = []
+        self.selenium_displayed = selenium_displayed
 
     async def inner_text(self):
         return self.text
@@ -68,6 +75,8 @@ class FakeLocator:
 
     async def evaluate(self, script, arg=None, **kwargs):
         self.evaluated.append((script, arg, kwargs))
+        if "apply(null, [element])" in script:
+            return self.selenium_displayed
         return "locator-result"
 
     async def get_attribute(self, name):
@@ -118,6 +127,18 @@ class FakeLocator:
 
     async def wait_for(self, **kwargs):
         self.wait_calls.append(kwargs)
+
+    def filter(self, **kwargs):
+        self.calls.append(("filter", kwargs))
+        return self
+
+    @property
+    def first(self):
+        return self
+
+    def nth(self, index):
+        self.calls.append(("nth", index))
+        return self
 
     async def count(self):
         self.calls.append(("count",))
@@ -591,8 +612,10 @@ def test_selenium_conditional_uses_playwright_when_runtime_driver_set(monkeypatc
 
 def test_legacy_wait_defaults_to_visible_with_action_timeout(monkeypatch):
     locator = FakeLocator()
+    calls = []
 
     async def fake_get_element(*args, **kwargs):
+        calls.append(kwargs)
         return locator
 
     monkeypatch.setattr(pw.PlaywrightLocator, "Get_Element", fake_get_element)
@@ -607,7 +630,49 @@ def test_legacy_wait_defaults_to_visible_with_action_timeout(monkeypatch):
     )
 
     assert result == "passed"
-    assert locator.wait_calls == [{"state": "visible", "timeout": 150000}]
+    assert calls == [{"element_wait": 150.0}]
+    assert locator.wait_calls == []
+
+
+def test_routed_legacy_wait_uses_single_shared_locator_wait():
+    locator = FakeLocator()
+    pw.current_page = FakePage(locator)
+    sr.Set_Shared_Variables("element_wait", 60)
+
+    result = asyncio.run(
+        pw.Wait_For_Element(
+            [
+                ("*class", "parent parameter", "navbar-expand-lg container-fluid navbar"),
+                ("*class", "element parameter", "small-nav"),
+                ("wait", "selenium action", "30"),
+            ]
+        )
+    )
+
+    assert result == "passed"
+    assert pw.current_page.queries == [
+        'xpath=//*[contains(@class,"small-nav")][(ancestor::*[contains(@class,"navbar-expand-lg container-fluid navbar")])[last()]]'
+    ]
+    assert locator.evaluated
+    assert locator.wait_calls == []
+
+
+def test_routed_legacy_wait_disable_uses_selenium_displayedness():
+    locator = FakeLocator(selenium_displayed=False)
+    pw.current_page = FakePage(locator)
+
+    result = asyncio.run(
+        pw.Wait_For_Element(
+            [
+                ("id", "element parameter", "hidden"),
+                ("wait disable", "selenium action", "0.1"),
+            ]
+        )
+    )
+
+    assert result == "passed"
+    assert locator.evaluated
+    assert locator.wait_calls == []
 
 
 def test_legacy_wait_with_allow_hidden_waits_for_attached(monkeypatch):

--- a/tests/test_playwright_locator.py
+++ b/tests/test_playwright_locator.py
@@ -7,7 +7,7 @@ from Framework.Built_In_Automation.Shared_Resources import (
 
 
 class FakeLocator:
-    def __init__(self, name="root", count=1, texts=None, text="", stats=None):
+    def __init__(self, name="root", count=1, texts=None, text="", stats=None, selenium_displayed=True):
         self.name = name
         self._count = count
         self.texts = texts or []
@@ -17,29 +17,30 @@ class FakeLocator:
         self.nth_index = None
         self.queries = []
         self.children = {}
+        self.selenium_displayed = selenium_displayed
 
     def locator(self, query):
         self.queries.append(query)
         child = self.children.get(query)
         if child:
             return child
-        return FakeLocator(f"{self.name}.locator({query})", self._count, self.texts, self.text, self.stats)
+        return FakeLocator(f"{self.name}.locator({query})", self._count, self.texts, self.text, self.stats, self.selenium_displayed)
 
     def filter(self, **kwargs):
-        filtered = FakeLocator(f"{self.name}.filter", self._count, self.texts, self.text, self.stats)
+        filtered = FakeLocator(f"{self.name}.filter", self._count, self.texts, self.text, self.stats, self.selenium_displayed)
         filtered.filtered = kwargs.get("visible") is True
         return filtered
 
     @property
     def first(self):
         text = self.texts[0] if self.texts else self.text
-        first = FakeLocator(f"{self.name}.first", min(self._count, 1), self.texts, text, self.stats)
+        first = FakeLocator(f"{self.name}.first", min(self._count, 1), self.texts, text, self.stats, self.selenium_displayed)
         first.filtered = self.filtered
         return first
 
     def nth(self, index):
         text = self.texts[index] if 0 <= index < len(self.texts) else self.text
-        nth = FakeLocator(f"{self.name}.nth({index})", 1, self.texts, text, self.stats)
+        nth = FakeLocator(f"{self.name}.nth({index})", 1, self.texts, text, self.stats, self.selenium_displayed)
         nth.nth_index = index
         nth.filtered = self.filtered
         nth.queries = self.queries
@@ -60,6 +61,10 @@ class FakeLocator:
 
     async def text_content(self):
         return self.text
+
+    async def evaluate(self, expression, **kwargs):
+        self.stats["evaluate"] = self.stats.get("evaluate", 0) + 1
+        return self.selenium_displayed
 
 
 class FakePage:
@@ -100,6 +105,61 @@ def test_normal_playwright_action_returns_lazy_visible_first_locator():
     assert result.name.endswith(".filter.first")
     assert result.filtered is True
     assert fake_locator.stats == {"wait": 0, "count": 0}
+
+
+def test_regular_action_row_forms_return_lazy_relationship_locator():
+    expected_query = 'xpath=//*[contains(@class,"small-nav")][(ancestor::*[contains(@class,"navbar-expand-lg container-fluid navbar")])[last()]]'
+
+    for action_subfield in ("action", "playwright action"):
+        fake_locator = FakeLocator(count=1)
+        page = FakePage(fake_locator)
+
+        result = run(
+            LocateElement.Get_Element(
+                [
+                    ("*class", "parent parameter", "navbar-expand-lg container-fluid navbar"),
+                    ("*class", "element parameter", "small-nav"),
+                    ("wait", action_subfield, "30"),
+                ],
+                page,
+            )
+        )
+
+        assert page.queries == [expected_query]
+        assert result.name.endswith(".filter.first")
+        assert fake_locator.stats == {"wait": 0, "count": 0}
+
+
+def test_selenium_action_uses_selenium_displayedness_for_relationship_locator():
+    fake_locator = FakeLocator(count=1)
+    page = FakePage(fake_locator)
+
+    result = run(
+        LocateElement.Get_Element(
+            [
+                ("*class", "parent parameter", "navbar-expand-lg container-fluid navbar"),
+                ("*class", "element parameter", "small-nav"),
+                ("wait", "selenium action", "30"),
+            ],
+            page,
+            element_wait=1,
+        )
+    )
+
+    assert result.nth_index == 0
+    assert fake_locator.stats == {"wait": 0, "count": 1, "evaluate": 1}
+
+
+def test_selenium_action_rejects_element_hidden_by_selenium_displayedness():
+    result = run(
+        LocateElement.Get_Element(
+            [("id", "element parameter", "hidden"), ("wait", "selenium action", "1")],
+            FakePage(FakeLocator(selenium_displayed=False)),
+            element_wait=0.01,
+        )
+    )
+
+    assert result == "zeuz_failed"
 
 
 def test_conditional_non_action_lookup_resolves_and_fails_on_no_match():


### PR DESCRIPTION
### Summary/TLDR

- Keep Selenium-authored browser actions portable when zeuz_browser_driver routes them through Playwright.
- Make the reported wait action pass unchanged under both Selenium and Playwright.

### Bug Report

A Selenium wait action succeeded with Selenium but timed out when runtime routing selected Playwright. Adding allow hidden made Playwright pass, but requiring driver-specific test data breaks routing parity.

### Root Cause

- Routed Selenium action rows were not consistently recognized by the shared Playwright lazy-locator path.
- Playwright native visibility is stricter than Selenium displayedness for some attached elements, so the same element was accepted by Selenium and rejected by Playwright.

### Solution

- Recognize normalized, Selenium, and Playwright browser-action row forms.
- Reuse the installed Selenium isDisplayed atom when Selenium-authored actions execute through Playwright.
- Preserve native Playwright visibility for Playwright-authored actions and explicit state or allow-hidden behavior.
- Apply the same compatibility semantics to wait and wait-disable actions.

### Tests/Validation

- 45 focused Playwright locator and action-parity tests passed.
- Full tests directory: 126 passed; one unrelated existing test failed because LocalRun calls main with an unsupported positional argument.